### PR TITLE
Fix #572 - Add ability to control engine state with Loop Back Adapter

### DIFF
--- a/src/org/etools/j1939_84/controllers/StepController.java
+++ b/src/org/etools/j1939_84/controllers/StepController.java
@@ -5,6 +5,7 @@ package org.etools.j1939_84.controllers;
 
 import static org.etools.j1939_84.J1939_84.NL;
 import static org.etools.j1939_84.J1939_84.isDevEnv;
+import static org.etools.j1939_84.J1939_84.isTesting;
 import static org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket.Response.NACK;
 import static org.etools.j1939_84.controllers.Controller.Ending.STOPPED;
 import static org.etools.j1939_84.controllers.QuestionListener.AnswerType.CANCEL;
@@ -98,6 +99,9 @@ public abstract class StepController extends Controller {
     protected void ensureKeyOnEngineOn() throws InterruptedException {
         try {
             getListener().onResult("Initial Engine Speed = " + getEngineSpeedModule().getEngineSpeed() + " RPMs");
+            if (isTesting()) {
+                getVehicleInformationModule().requestKeyOnEngineOn(getListener());
+            }
             if (!getEngineSpeedModule().isEngineRunning() && !isDevEnv()) {
                 getListener().onUrgentMessage("Please turn the Key ON with Engine ON", "Adjust Key Switch", WARNING);
                 while (!getEngineSpeedModule().isEngineRunning()) {
@@ -121,6 +125,9 @@ public abstract class StepController extends Controller {
     protected void ensureKeyOnEngineOff() throws InterruptedException {
         try {
             getListener().onResult("Initial Engine Speed = " + getEngineSpeedModule().getEngineSpeed() + " RPMs");
+            if (isTesting()) {
+                getVehicleInformationModule().requestKeyOnEngineOff(getListener());
+            }
             if (!getEngineSpeedModule().isEngineNotRunning() && !isDevEnv()) {
                 getListener().onUrgentMessage("Please turn the Key ON with Engine OFF", "Adjust Key Switch", WARNING);
                 while (!getEngineSpeedModule().isEngineNotRunning()) {
@@ -144,6 +151,9 @@ public abstract class StepController extends Controller {
     protected void ensureKeyOffEngineOff() throws InterruptedException {
         try {
             getListener().onResult("Initial Engine Speed = " + getEngineSpeedModule().getEngineSpeed() + " RPMs");
+            if (isTesting()) {
+                getVehicleInformationModule().requestKeyOffEngineOff(getListener());
+            }
             if (getEngineSpeedModule().isEngineCommunicating() && !isDevEnv()) {
                 getListener().onUrgentMessage("Please turn the Key OFF with Engine OFF", "Adjust Key Switch", WARNING);
                 while (getEngineSpeedModule().isEngineCommunicating()) {
@@ -256,6 +266,7 @@ public abstract class StepController extends Controller {
                 .map(moduleName -> section + " - OBD module " + moduleName + " did not provide a NACK for the DS query")
                 .forEach(this::addFailure);
     }
+
     protected void waitForFault(String boxTitle) {
         String message = "Implant Fault A according to engine manufacturer’s instruction" + NL;
         message += "Press OK when ready to continue testing" + NL;

--- a/src/org/etools/j1939_84/modules/VehicleInformationModule.java
+++ b/src/org/etools/j1939_84/modules/VehicleInformationModule.java
@@ -309,6 +309,33 @@ public class VehicleInformationModule extends FunctionalModule {
                 .collect(Collectors.toList());
     }
 
+    public void requestKeyOnEngineOff(ResultsListener listener) {
+        requestKeyStateEngineState(true, false, listener);
+    }
+
+    public void requestKeyOnEngineOn(ResultsListener listener) {
+        requestKeyStateEngineState(true, true, listener);
+    }
+
+    public void requestKeyOffEngineOff(ResultsListener listener) {
+        requestKeyStateEngineState(false, false, listener);
+    }
+
+    private void requestKeyStateEngineState(boolean isKeyOn, boolean isEngineOn, ResultsListener listener) {
+        int pgn;
+        if (isKeyOn && isEngineOn) {
+            pgn = 0x1FFFF;
+        } else if (isKeyOn) {
+            pgn = 0x1FFFE;
+        } else {
+            pgn = 0x1FFFC;
+        }
+        getJ1939().requestGlobal("Requesting Key " + isKeyOn + " Engine " + isEngineOn + " - REPORT IF SEEN IN THE FIELD",
+                                 pgn,
+                                 getJ1939().createRequestPacket(pgn, GLOBAL_ADDR),
+                                 listener);
+    }
+
     /**
      * Clears the cached values that have been read from the vehicle
      */


### PR DESCRIPTION
This adds the ability to turn off and off the look back adapter engine.

TESTING = "true" must be passed into program arguments to active the loopback adapter and this feature.

In the `StepController`, it will send specific messages which the `Engine` will read and interpret to change the key and engine states.  (In reality it changes the value and transmission of the engine speed message).

There is message written into the logs as this functionality shouldn't escape the developer as this does transmit an un-required message onto the bus.