### PR TITLE
Fix #282 Implement Part3 Step 13

### DIFF
--- a/src-test/org/etools/j1939_84/bus/j1939/packets/DM24SPNSupportPacketTest.java
+++ b/src-test/org/etools/j1939_84/bus/j1939/packets/DM24SPNSupportPacketTest.java
@@ -319,6 +319,74 @@ public class DM24SPNSupportPacketTest {
         expected += "  SPN 5837 - Fuel Type" + NL;
         expected += "]" + NL;
         assertEquals(expected, instance.toString());
+
+        List<SupportedSPN> actualSPNs = instance.getFreezeFrameSPNsInOrder();
+        StringBuilder actualSPNString = new StringBuilder();
+        for (SupportedSPN spn : actualSPNs) {
+            actualSPNString.append(spn).append(NL);
+        }
+        String expectedSPNString = "";
+        expectedSPNString += "SPN 92 - Engine Percent Load At Current Speed" + NL;
+        expectedSPNString += "SPN 512 - Driver's Demand Engine - Percent Torque" + NL;
+        expectedSPNString += "SPN 513 - Actual Engine - Percent Torque" + NL;
+        expectedSPNString += "SPN 544 - Engine Reference Torque" + NL;
+        expectedSPNString += "SPN 539 - Engine Percent Torque At Idle, Point 1" + NL;
+        expectedSPNString += "SPN 540 - Engine Percent Torque At Point 2" + NL;
+        expectedSPNString += "SPN 541 - Engine Percent Torque At Point 3" + NL;
+        expectedSPNString += "SPN 542 - Engine Percent Torque At Point 4" + NL;
+        expectedSPNString += "SPN 543 - Engine Percent Torque At Point 5" + NL;
+        expectedSPNString += "SPN 110 - Engine Coolant Temperature" + NL;
+        expectedSPNString += "SPN 175 - Engine Oil Temperature 1" + NL;
+        expectedSPNString += "SPN 190 - Engine Speed" + NL;
+        expectedSPNString += "SPN 84 - Wheel-Based Vehicle Speed" + NL;
+        expectedSPNString += "SPN 108 - Barometric Pressure" + NL;
+        expectedSPNString += "SPN 158 - Key Switch Battery Potential" + NL;
+        expectedSPNString += "SPN 51 - Engine Throttle Valve 1 Position 1" + NL;
+        expectedSPNString += "SPN 94 - Engine Fuel Delivery Pressure" + NL;
+        expectedSPNString += "SPN 172 - Engine Intake 1 Air Temperature" + NL;
+        expectedSPNString += "SPN 105 - Engine Intake Manifold 1 Temperature" + NL;
+        expectedSPNString += "SPN 132 - Engine Intake Air Mass Flow Rate" + NL;
+        expectedSPNString += "SPN 976 - PTO Governor State" + NL;
+        expectedSPNString += "SPN 91 - Accelerator Pedal Position 1" + NL;
+        expectedSPNString += "SPN 183 - Engine Fuel Rate" + NL;
+        expectedSPNString += "SPN 102 - Engine Intake Manifold #1 Pressure" + NL;
+        expectedSPNString += "SPN 173 - Engine Exhaust Temperature" + NL;
+        expectedSPNString += "SPN 3251 - AFT 1 DPF Differential Pressure" + NL;
+        expectedSPNString += "SPN 3483 - AFT 1 Regeneration Status" + NL;
+        expectedSPNString += "SPN 5837 - Fuel Type" + NL;
+        expectedSPNString += "SPN 3301 - Time Since Engine Start" + NL;
+        expectedSPNString += "SPN 5466 - AFT 1 DPF Soot Load Regeneration Threshold" + NL;
+        expectedSPNString += "SPN 5323 - Engine Fuel Control Mode" + NL;
+        expectedSPNString += "SPN 3464 - Engine Throttle Actuator 1 Control Command" + NL;
+        expectedSPNString += "SPN 1209 - Engine Exhaust Pressure 1" + NL;
+        expectedSPNString += "SPN 5541 - Engine Turbocharger 1 Turbine Outlet Pressure" + NL;
+        expectedSPNString += "SPN 164 - Engine Fuel Injection Control Pressure" + NL;
+        expectedSPNString += "SPN 2791 - Engine EGR 1 Valve 1 Control 1" + NL;
+        expectedSPNString += "SPN 1413 - Engine Cylinder 1 Ignition Timing" + NL;
+        expectedSPNString += "SPN 1414 - Engine Cylinder 2 Ignition Timing" + NL;
+        expectedSPNString += "SPN 1415 - Engine Cylinder 3 Ignition Timing" + NL;
+        expectedSPNString += "SPN 1416 - Engine Cylinder 4 Ignition Timing" + NL;
+        expectedSPNString += "SPN 1417 - Engine Cylinder 5 Ignition Timing" + NL;
+        expectedSPNString += "SPN 1418 - Engine Cylinder 6 Ignition Timing" + NL;
+        expectedSPNString += "SPN 3563 - Engine Intake Manifold #1 Absolute Pressure" + NL;
+        expectedSPNString += "SPN 27 - Engine EGR 1 Valve Position" + NL;
+        expectedSPNString += "SPN 3242 - AFT 1 DPF Intake Temperature" + NL;
+        expectedSPNString += "SPN 3246 - AFT 1 DPF Outlet Temperature" + NL;
+        expectedSPNString += "SPN 3216 - Engine Exhaust 1 NOx 1" + NL;
+        expectedSPNString += "SPN 1081 - Engine Wait to Start Lamp" + NL;
+        expectedSPNString += "SPN 1189 - Engine Turbocharger Wastegate Actuator 2 Position" + NL;
+        expectedSPNString += "SPN 5314 - Commanded Engine Fuel Injection Control Pressure" + NL;
+        expectedSPNString += "SPN 3609 - AFT 1 DPF Intake Pressure" + NL;
+        expectedSPNString += "SPN 3480 - AFT 1 Fuel Pressure 1" + NL;
+        expectedSPNString += "SPN 3226 - AFT 1 Outlet NOx 1" + NL;
+        expectedSPNString += "SPN 1761 - AFT 1 DEF Tank Volume" + NL;
+        expectedSPNString += "SPN 3482 - AFT 1 Fuel Enable Actuator" + NL;
+        expectedSPNString += "SPN 3490 - AFT 1 Purge Air Actuator" + NL;
+        expectedSPNString += "SPN 4360 - AFT 1 SCR Intake Temperature" + NL;
+        expectedSPNString += "SPN 4363 - AFT 1 SCR Outlet Temperature" + NL;
+        expectedSPNString += "SPN 3031 - AFT 1 DEF Tank Temperature 1" + NL;
+        expectedSPNString += "SPN 1173 - Engine Turbocharger 2 Compressor Intake Temperature" + NL;
+        assertEquals(expectedSPNString, actualSPNString.toString());
     }
 
     @Test

--- a/src-test/org/etools/j1939_84/bus/j1939/packets/DM25ExpandedFreezeFrameTest.java
+++ b/src-test/org/etools/j1939_84/bus/j1939/packets/DM25ExpandedFreezeFrameTest.java
@@ -4,6 +4,7 @@
 package org.etools.j1939_84.bus.j1939.packets;
 
 import static org.etools.j1939_84.J1939_84.NL;
+import static org.etools.j1939_84.bus.j1939.packets.DM25ExpandedFreezeFrame.PGN;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
@@ -20,16 +21,9 @@ public class DM25ExpandedFreezeFrameTest {
 
     @Test
     public void testActual() {
-        Packet packet = Packet.create(DM25ExpandedFreezeFrame.PGN,
+        Packet packet = Packet.create(PGN,
                                       0,
-                                      0x00,
-                                      0x00,
-                                      0x00,
-                                      0x00,
-                                      0x00,
-                                      0xFF,
-                                      0xFF,
-                                      0xFF);
+                                      0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF);
         DM25ExpandedFreezeFrame instance = new DM25ExpandedFreezeFrame(packet);
         List<FreezeFrame> freezeFrame = instance.getFreezeFrames();
         assertEquals(0, freezeFrame.size());
@@ -42,16 +36,9 @@ public class DM25ExpandedFreezeFrameTest {
 
     @Test
     public void testActualWithBadFmi() {
-        Packet packet = Packet.create(DM25ExpandedFreezeFrame.PGN,
+        Packet packet = Packet.create(PGN,
                                       0,
-                                      0x00,
-                                      0x00,
-                                      0x00,
-                                      0x00,
-                                      0x00,
-                                      0xFF,
-                                      0xFE,
-                                      0xFF);
+                                      0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFE, 0xFF);
         DM25ExpandedFreezeFrame instance = new DM25ExpandedFreezeFrame(packet);
         List<FreezeFrame> freezeFrames = instance.getFreezeFrames();
         assertEquals(1, freezeFrames.size());
@@ -60,27 +47,22 @@ public class DM25ExpandedFreezeFrameTest {
         DiagnosticTroubleCode dtc = freezeFrame.getDtc();
         assertEquals(0, dtc.getSuspectParameterNumber());
         assertEquals(0, dtc.getFailureModeIndicator());
-        assertArrayEquals(new int[] { 0xFF, 0xFE, 0xFF }, freezeFrame.getSpnData());
+        assertArrayEquals(new int[] { 0xFF, 0xFE, 0xFF ,0x00}, freezeFrame.getSpnData());
         String expected = "DM25 from Engine #1 (0): " + NL;
         expected += "Freeze Frames: [" + NL;
+        expected += "Freeze Frame: {" + NL;
         expected += "DTC 0:0 - Unknown, Data Valid But Above Normal Operational Range - Most Severe Level - 0 times" + NL;
-        expected += "SPN Data: FF FE FF" + NL;
+        expected += "SPN Data: FF FE FF 00" + NL;
+        expected += "}" + NL;
         expected += "]";
         assertEquals(expected, instance.toString());
     }
 
     @Test
     public void testActualWithBadSpn() {
-        Packet packet = Packet.create(DM25ExpandedFreezeFrame.PGN,
+        Packet packet = Packet.create(PGN,
                                       0,
-                                      0x00,
-                                      0x01,
-                                      0x00,
-                                      0x00,
-                                      0x00,
-                                      0xFF,
-                                      0xFF,
-                                      0xFF);
+                                      0x00, 0x01, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF);
 
         DM25ExpandedFreezeFrame instance = new DM25ExpandedFreezeFrame(packet);
 
@@ -91,106 +73,34 @@ public class DM25ExpandedFreezeFrameTest {
         DiagnosticTroubleCode dtc = freezeFrame.getDtc();
         assertEquals(1, dtc.getSuspectParameterNumber());
         assertEquals(0, dtc.getFailureModeIndicator());
-        assertArrayEquals(new int[] { 0xFF, 0xFF, 0xFF }, freezeFrame.getSpnData());
+        assertArrayEquals(new int[] { 0xFF, 0xFF, 0xFF, 0x00 }, freezeFrame.getSpnData());
 
         String expected = "DM25 from Engine #1 (0): " + NL;
         expected += "Freeze Frames: [" + NL;
+        expected += "Freeze Frame: {" + NL;
         expected += "DTC 1:0 - Unknown, Data Valid But Above Normal Operational Range - Most Severe Level - 0 times" + NL;
-        expected += "SPN Data: FF FF FF" + NL;
+        expected += "SPN Data: FF FF FF 00" + NL;
+        expected += "}" + NL;
         expected += "]";
         assertEquals(expected, instance.toString());
     }
 
     @Test
     public void testOne() {
+        //@formatter:off
         int[] realData = new int[] {
-                0x56,
-                0x9D,
-                0x00,
-                0x07,
-                0x7F,
-                0x00,
-                0x01,
-                0x7B,
-                0x00,
-                0x00,
-                0x39,
-                0x3A,
-                0x5C,
-                0x0F,
-                0xC4,
-                0xFB,
-                0x00,
-                0x00,
-                0x00,
-                0xF1,
-                0x26,
-                0x00,
-                0x00,
-                0x00,
-                0x12,
-                0x7A,
-                0x7D,
-                0x80,
-                0x65,
-                0x00,
-                0x00,
-                0x32,
-                0x00,
-                0x00,
-                0x00,
-                0x00,
-                0x84,
-                0xAD,
-                0x00,
-                0x39,
-                0x2C,
-                0x30,
-                0x39,
-                0xFC,
-                0x38,
-                0xC6,
-                0x35,
-                0xE0,
-                0x34,
-                0x2C,
-                0x2F,
-                0x00,
-                0x00,
-                0x7D,
-                0x7D,
-                0x8A,
-                0x28,
-                0xA0,
-                0x0F,
-                0xA0,
-                0x0F,
-                0xD1,
-                0x37,
-                0x00,
-                0xCA,
-                0x28,
-                0x01,
-                0xA4,
-                0x0D,
-                0x00,
-                0xA8,
-                0xC3,
-                0xB2,
-                0xC2,
-                0xC3,
-                0x00,
-                0x00,
-                0x00,
-                0x00,
-                0x7E,
-                0xD0,
-                0x07,
-                0x00,
-                0x7D,
-                0x04,
-                0xFF,
-                0xFA };
+                0x56, 0x9D, 0x00, 0x07, 0x7F, 0x00, 0x01, 0x7B,
+                0x00, 0x00, 0x39, 0x3A, 0x5C, 0x0F, 0xC4, 0xFB,
+                0x00, 0x00, 0x00, 0xF1, 0x26, 0x00, 0x00, 0x00,
+                0x12, 0x7A, 0x7D, 0x80, 0x65, 0x00, 0x00, 0x32,
+                0x00, 0x00, 0x00, 0x00, 0x84, 0xAD, 0x00, 0x39,
+                0x2C, 0x30, 0x39, 0xFC, 0x38, 0xC6, 0x35, 0xE0,
+                0x34, 0x2C, 0x2F, 0x00, 0x00, 0x7D, 0x7D, 0x8A,
+                0x28, 0xA0, 0x0F, 0xA0, 0x0F, 0xD1, 0x37, 0x00,
+                0xCA, 0x28, 0x01, 0xA4, 0x0D, 0x00, 0xA8, 0xC3,
+                0xB2, 0xC2, 0xC3, 0x00, 0x00, 0x00, 0x00, 0x7E,
+                0xD0, 0x07, 0x00, 0x7D, 0x04, 0xFF, 0xFA };
+        //@formatter:on
 
         Packet packet = Packet.create(0x00, 0x00, realData);
         DM25ExpandedFreezeFrame instance = new DM25ExpandedFreezeFrame(packet);
@@ -202,196 +112,48 @@ public class DM25ExpandedFreezeFrameTest {
         assertEquals(7, actual.getDtc().getFailureModeIndicator());
         String expected = "DM25 from Engine #1 (0): " + NL;
         expected += "Freeze Frames: [" + NL;
+        expected += "Freeze Frame: {" + NL;
         expected += "DTC 157:7 - Engine Fuel 1 Injector Metering Rail 1 Pressure, Mechanical System Not Responding Or Out Of Adjustment"
                 + NL;
-        expected += "SPN Data: 00 01 7B 00 00 39 3A 5C 0F C4 FB 00 00 00 F1 26 00 00 00 12 7A 7D 80 65 00 00 32 00 00 00 00 84 AD 00 39 2C 30 39 FC 38 C6 35 E0 34 2C 2F 00 00 7D 7D 8A 28 A0 0F A0 0F D1 37 00 CA 28 01 A4 0D 00 A8 C3 B2 C2 C3 00 00 00 00 7E D0 07 00 7D 04 FF"
+        expected += "SPN Data: 00 01 7B 00 00 39 3A 5C 0F C4 FB 00 00 00 F1 26 00 00 00 12 7A 7D 80 65 00 00 32 00 00 00 00 84 AD 00 39 2C 30 39 FC 38 C6 35 E0 34 2C 2F 00 00 7D 7D 8A 28 A0 0F A0 0F D1 37 00 CA 28 01 A4 0D 00 A8 C3 B2 C2 C3 00 00 00 00 7E D0 07 00 7D 04 FF FA"
                 + NL;
+        expected += "}" + NL;
         expected += "]";
         assertEquals(expected, instance.toString());
     }
 
     @Test
     public void testPGN() {
-        assertEquals(64951, DM25ExpandedFreezeFrame.PGN);
+        assertEquals(64951, PGN);
     }
 
     @Test
     public void testTwo() {
+        //@formatter:off
         int[] realData = new int[] {
-                0x56,
-                0x9D,
-                0x00,
-                0x07,
-                0x7F,
-                0x00,
-                0x01,
-                0x7B,
-                0x00,
-                0x00,
-                0x39,
-                0x3A,
-                0x5C,
-                0x0F,
-                0xC4,
-                0xFB,
-                0x00,
-                0x00,
-                0x00,
-                0xF1,
-                0x26,
-                0x00,
-                0x00,
-                0x00,
-                0x12,
-                0x7A,
-                0x7D,
-                0x80,
-                0x65,
-                0x00,
-                0x00,
-                0x32,
-                0x00,
-                0x00,
-                0x00,
-                0x00,
-                0x84,
-                0xAD,
-                0x00,
-                0x39,
-                0x2C,
-                0x30,
-                0x39,
-                0xFC,
-                0x38,
-                0xC6,
-                0x35,
-                0xE0,
-                0x34,
-                0x2C,
-                0x2F,
-                0x00,
-                0x00,
-                0x7D,
-                0x7D,
-                0x8A,
-                0x28,
-                0xA0,
-                0x0F,
-                0xA0,
-                0x0F,
-                0xD1,
-                0x37,
-                0x00,
-                0xCA,
-                0x28,
-                0x01,
-                0xA4,
-                0x0D,
-                0x00,
-                0xA8,
-                0xC3,
-                0xB2,
-                0xC2,
-                0xC3,
-                0x00,
-                0x00,
-                0x00,
-                0x00,
-                0x7E,
-                0xD0,
-                0x07,
-                0x00,
-                0x7D,
-                0x04,
-                0xFF,
-                0xFA,
-                0x56,
-                0x9D,
-                0x00,
-                0x07,
-                0x7F,
-                0x00,
-                0x01,
-                0x7B,
-                0x00,
-                0x00,
-                0x39,
-                0x3A,
-                0x5C,
-                0x0F,
-                0xC4,
-                0xFB,
-                0x00,
-                0x00,
-                0x00,
-                0xF1,
-                0x26,
-                0x00,
-                0x00,
-                0x00,
-                0x12,
-                0x7A,
-                0x7D,
-                0x80,
-                0x65,
-                0x00,
-                0x00,
-                0x32,
-                0x00,
-                0x00,
-                0x00,
-                0x00,
-                0x84,
-                0xAD,
-                0x00,
-                0x39,
-                0x2C,
-                0x30,
-                0x39,
-                0xFC,
-                0x38,
-                0xC6,
-                0x35,
-                0xE0,
-                0x34,
-                0x2C,
-                0x2F,
-                0x00,
-                0x00,
-                0x7D,
-                0x7D,
-                0x8A,
-                0x28,
-                0xA0,
-                0x0F,
-                0xA0,
-                0x0F,
-                0xD1,
-                0x37,
-                0x00,
-                0xCA,
-                0x28,
-                0x01,
-                0xA4,
-                0x0D,
-                0x00,
-                0xA8,
-                0xC3,
-                0xB2,
-                0xC2,
-                0xC3,
-                0x00,
-                0x00,
-                0x00,
-                0x00,
-                0x7E,
-                0xD0,
-                0x07,
-                0x00,
-                0x7D,
-                0x04,
-                0xFF,
-                0xFA };
+                0x56, 0x9D, 0x00, 0x07, 0x7F, 0x00, 0x01, 0x7B,
+                0x00, 0x00, 0x39, 0x3A, 0x5C, 0x0F, 0xC4, 0xFB,
+                0x00, 0x00, 0x00, 0xF1, 0x26, 0x00, 0x00, 0x00,
+                0x12, 0x7A, 0x7D, 0x80, 0x65, 0x00, 0x00, 0x32,
+                0x00, 0x00, 0x00, 0x00, 0x84, 0xAD, 0x00, 0x39,
+                0x2C, 0x30, 0x39, 0xFC, 0x38, 0xC6, 0x35, 0xE0,
+                0x34, 0x2C, 0x2F, 0x00, 0x00, 0x7D, 0x7D, 0x8A,
+                0x28, 0xA0, 0x0F, 0xA0, 0x0F, 0xD1, 0x37, 0x00,
+                0xCA, 0x28, 0x01, 0xA4, 0x0D, 0x00, 0xA8, 0xC3,
+                0xB2, 0xC2, 0xC3, 0x00, 0x00, 0x00, 0x00, 0x7E,
+                0xD0, 0x07, 0x00, 0x7D, 0x04, 0xFF, 0xFA ,
+                0x56, 0x9D, 0x00, 0x07, 0x7F, 0x00, 0x01, 0x7B,
+                0x00, 0x00, 0x39, 0x3A, 0x5C, 0x0F, 0xC4, 0xFB,
+                0x00, 0x00, 0x00, 0xF1, 0x26, 0x00, 0x00, 0x00,
+                0x12, 0x7A, 0x7D, 0x80, 0x65, 0x00, 0x00, 0x32,
+                0x00, 0x00, 0x00, 0x00, 0x84, 0xAD, 0x00, 0x39,
+                0x2C, 0x30, 0x39, 0xFC, 0x38, 0xC6, 0x35, 0xE0,
+                0x34, 0x2C, 0x2F, 0x00, 0x00, 0x7D, 0x7D, 0x8A,
+                0x28, 0xA0, 0x0F, 0xA0, 0x0F, 0xD1, 0x37, 0x00,
+                0xCA, 0x28, 0x01, 0xA4, 0x0D, 0x00, 0xA8, 0xC3,
+                0xB2, 0xC2, 0xC3, 0x00, 0x00, 0x00, 0x00, 0x7E,
+                0xD0, 0x07, 0x00, 0x7D, 0x04, 0xFF, 0xFA };
+        //@formatter:on
 
         Packet packet = Packet.create(0x00, 0x00, realData);
         DM25ExpandedFreezeFrame instance = new DM25ExpandedFreezeFrame(packet);
@@ -406,14 +168,18 @@ public class DM25ExpandedFreezeFrameTest {
 
         String expected = "DM25 from Engine #1 (0): " + NL;
         expected += "Freeze Frames: [" + NL;
+        expected += "Freeze Frame: {" + NL;
         expected += "DTC 157:7 - Engine Fuel 1 Injector Metering Rail 1 Pressure, Mechanical System Not Responding Or Out Of Adjustment"
                 + NL;
-        expected += "SPN Data: 00 01 7B 00 00 39 3A 5C 0F C4 FB 00 00 00 F1 26 00 00 00 12 7A 7D 80 65 00 00 32 00 00 00 00 84 AD 00 39 2C 30 39 FC 38 C6 35 E0 34 2C 2F 00 00 7D 7D 8A 28 A0 0F A0 0F D1 37 00 CA 28 01 A4 0D 00 A8 C3 B2 C2 C3 00 00 00 00 7E D0 07 00 7D 04 FF"
+        expected += "SPN Data: 00 01 7B 00 00 39 3A 5C 0F C4 FB 00 00 00 F1 26 00 00 00 12 7A 7D 80 65 00 00 32 00 00 00 00 84 AD 00 39 2C 30 39 FC 38 C6 35 E0 34 2C 2F 00 00 7D 7D 8A 28 A0 0F A0 0F D1 37 00 CA 28 01 A4 0D 00 A8 C3 B2 C2 C3 00 00 00 00 7E D0 07 00 7D 04 FF FA"
                 + NL;
+        expected += "}" + NL;
+        expected += "Freeze Frame: {" + NL;
         expected += "DTC 157:7 - Engine Fuel 1 Injector Metering Rail 1 Pressure, Mechanical System Not Responding Or Out Of Adjustment"
                 + NL;
-        expected += "SPN Data: 00 01 7B 00 00 39 3A 5C 0F C4 FB 00 00 00 F1 26 00 00 00 12 7A 7D 80 65 00 00 32 00 00 00 00 84 AD 00 39 2C 30 39 FC 38 C6 35 E0 34 2C 2F 00 00 7D 7D 8A 28 A0 0F A0 0F D1 37 00 CA 28 01 A4 0D 00 A8 C3 B2 C2 C3 00 00 00 00 7E D0 07 00 7D 04 FF"
+        expected += "SPN Data: 00 01 7B 00 00 39 3A 5C 0F C4 FB 00 00 00 F1 26 00 00 00 12 7A 7D 80 65 00 00 32 00 00 00 00 84 AD 00 39 2C 30 39 FC 38 C6 35 E0 34 2C 2F 00 00 7D 7D 8A 28 A0 0F A0 0F D1 37 00 CA 28 01 A4 0D 00 A8 C3 B2 C2 C3 00 00 00 00 7E D0 07 00 7D 04 FF FA"
                 + NL;
+        expected += "}" + NL;
         expected += "]";
 
         assertEquals(expected, instance.toString());

--- a/src-test/org/etools/j1939_84/bus/j1939/packets/ScaledTestResultTest.java
+++ b/src-test/org/etools/j1939_84/bus/j1939/packets/ScaledTestResultTest.java
@@ -8,7 +8,6 @@ import static org.etools.j1939_84.bus.j1939.packets.ScaledTestResult.TestResult.
 import static org.etools.j1939_84.bus.j1939.packets.ScaledTestResult.TestResult.NOT_COMPLETE;
 import static org.etools.j1939_84.bus.j1939.packets.ScaledTestResult.TestResult.PASSED;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 import org.etools.j1939_84.bus.j1939.packets.ScaledTestResult.TestResult;
 import org.junit.Test;
@@ -217,7 +216,6 @@ public class ScaledTestResultTest {
         ScaledTestResult instance = new ScaledTestResult(data);
         assertEquals(3556, instance.getSpn());
         assertEquals(18, instance.getFmi());
-        assertNull(instance.getSlot());
         assertEquals(247, instance.getTestIdentifier());
         assertEquals(64255, instance.getTestValue());
         assertEquals(64255, instance.getTestMaximum());

--- a/src-test/org/etools/j1939_84/bus/j1939/packets/SlotTest.java
+++ b/src-test/org/etools/j1939_84/bus/j1939/packets/SlotTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import org.etools.j1939_84.bus.j1939.J1939DaRepository;
 import org.junit.Test;
 
 /**
@@ -18,7 +19,7 @@ import org.junit.Test;
 public class SlotTest {
     @Test
     public void test10BitsAsPercent() {
-        Slot slot = Slot.findSlot(205);
+        Slot slot = J1939DaRepository.findSlot(205);
         byte[] data = { (byte) 0x5A, (byte) 0xA5 };
         assertEquals("34.600000 %", slot.asString(data));
         assertFalse(slot.isNotAvailable(data));
@@ -32,7 +33,7 @@ public class SlotTest {
 
     @Test
     public void test11Bits() {
-        Slot slot = Slot.findSlot(218);
+        Slot slot = J1939DaRepository.findSlot(218);
         byte[] data = { (byte) 0x5A, (byte) 0xA5 };
         assertEquals("10101011010", slot.asString(data));
         assertFalse(slot.isNotAvailable(data));
@@ -51,7 +52,7 @@ public class SlotTest {
 
     @Test
     public void test12Bits() {
-        Slot slot = Slot.findSlot(281);
+        Slot slot = J1939DaRepository.findSlot(281);
         byte[] data = { (byte) 0x5A, (byte) 0xA5 };
         assertEquals("010101011010", slot.asString(data));
         assertFalse(slot.isNotAvailable(data));
@@ -70,7 +71,7 @@ public class SlotTest {
 
     @Test
     public void test16Bits() {
-        Slot slot = Slot.findSlot(276);
+        Slot slot = J1939DaRepository.findSlot(276);
         byte[] data = { (byte) 0x5A, (byte) 0xA5 };
         assertEquals("1010010101011010", slot.asString(data));
         assertFalse(slot.isNotAvailable(data));
@@ -89,7 +90,7 @@ public class SlotTest {
 
     @Test
     public void test1Bit() {
-        Slot slot = Slot.findSlot(86);
+        Slot slot = J1939DaRepository.findSlot(86);
 
         byte[] data = { 1 };
         assertEquals("1", slot.asString(data));
@@ -104,7 +105,7 @@ public class SlotTest {
 
     @Test
     public void test1Byte() {
-        Slot slot = Slot.findSlot(2);
+        Slot slot = J1939DaRepository.findSlot(2);
         byte[] data = { (byte) 0xA5 };
         assertEquals("1320.000000 kPa", slot.asString(data));
         assertFalse(slot.isNotAvailable(data));
@@ -123,7 +124,7 @@ public class SlotTest {
 
     @Test
     public void test21Bits() {
-        Slot slot = Slot.findSlot(217);
+        Slot slot = J1939DaRepository.findSlot(217);
         byte[] data = { (byte) 0xA5, (byte) 0x5A, (byte) 0xA5 };
         assertEquals("001010101101010100101", slot.asString(data));
         assertFalse(slot.isNotAvailable(data));
@@ -142,7 +143,7 @@ public class SlotTest {
 
     @Test
     public void test24Bits() {
-        Slot slot = Slot.findSlot(280);
+        Slot slot = J1939DaRepository.findSlot(280);
         byte[] data = { (byte) 0xA5, (byte) 0x5A, (byte) 0xA5 };
         assertEquals("101001010101101010100101", slot.asString(data));
         assertFalse(slot.isNotAvailable(data));
@@ -161,7 +162,7 @@ public class SlotTest {
 
     @Test
     public void test2Bits() {
-        Slot instance = Slot.findSlot(87);
+        Slot instance = J1939DaRepository.findSlot(87);
         byte[] data = { (byte) 0xA5 };
         assertEquals("01", instance.asString(data));
         assertFalse(instance.isNotAvailable(data));
@@ -180,7 +181,7 @@ public class SlotTest {
 
     @Test
     public void test2Bytes() {
-        Slot slot = Slot.findSlot(13);
+        Slot slot = J1939DaRepository.findSlot(13);
         byte[] data = { (byte) 0x5A, (byte) 0xA5 };
         assertEquals("1033.000000 mm", slot.asString(data));
         assertFalse(slot.isNotAvailable(data));
@@ -199,7 +200,7 @@ public class SlotTest {
 
     @Test
     public void test32Bits() {
-        Slot slot = Slot.findSlot(245);
+        Slot slot = J1939DaRepository.findSlot(245);
         byte[] data = { (byte) 0xA5, (byte) 0x5A, (byte) 0xA5, (byte) 0x5A };
         assertEquals("01011010101001010101101010100101", slot.asString(data));
         assertFalse(slot.isNotAvailable(data));
@@ -218,7 +219,7 @@ public class SlotTest {
 
     @Test
     public void test3Bits() {
-        Slot slot = Slot.findSlot(88);
+        Slot slot = J1939DaRepository.findSlot(88);
         byte[] data = { (byte) 0xA5 };
         assertEquals("101", slot.asString(data));
         assertFalse(slot.isNotAvailable(data));
@@ -237,7 +238,7 @@ public class SlotTest {
 
     @Test
     public void test3Bytes() {
-        Slot slot = Slot.findSlot(122);
+        Slot slot = J1939DaRepository.findSlot(122);
         byte[] data = { (byte) 0xA5, (byte) 0x5A, (byte) 0xA5 };
         assertEquals("21673290.000000 kg", slot.asString(data));
         assertFalse(slot.isNotAvailable(data));
@@ -256,7 +257,7 @@ public class SlotTest {
 
     @Test
     public void test4Bits() {
-        Slot slot = Slot.findSlot(89);
+        Slot slot = J1939DaRepository.findSlot(89);
         byte[] data = { (byte) 0xA5 };
         assertEquals("0101", slot.asString(data));
         assertFalse(slot.isNotAvailable(data));
@@ -276,7 +277,7 @@ public class SlotTest {
 
     @Test
     public void test4Bytes() {
-        Slot slot = Slot.findSlot(6);
+        Slot slot = J1939DaRepository.findSlot(6);
         byte[] data = { (byte) 0x5A, (byte) 0xA5, (byte) 0x5A, (byte) 0xA5 };
         assertEquals("2774181210.000000 s", slot.asString(data));
         assertFalse(slot.isNotAvailable(data));
@@ -295,7 +296,7 @@ public class SlotTest {
 
     @Test
     public void test5BytesASCII() {
-        Slot slot = Slot.findSlot(273);
+        Slot slot = J1939DaRepository.findSlot(273);
         byte[] data = "12345".getBytes();
         assertEquals("12345", slot.asString(data));
         assertFalse(slot.isNotAvailable(data));
@@ -304,7 +305,7 @@ public class SlotTest {
 
     @Test
     public void test64Bits() {
-        Slot slot = Slot.findSlot(278);
+        Slot slot = J1939DaRepository.findSlot(278);
 
         byte[] data = { (byte) 0xA5, (byte) 0x5A, (byte) 0xA5, (byte) 0x5A, (byte) 0xA5, (byte) 0x5A, (byte) 0xA5,
                 (byte) 0x5A };
@@ -327,7 +328,7 @@ public class SlotTest {
 
     @Test
     public void test6Bits() {
-        Slot slot = Slot.findSlot(91);
+        Slot slot = J1939DaRepository.findSlot(91);
         byte[] data = { (byte) 0xA5 };
         assertEquals("100101", slot.asString(data));
         assertFalse(slot.isNotAvailable(data));
@@ -346,7 +347,7 @@ public class SlotTest {
 
     @Test
     public void test7Bits() {
-        Slot slot = Slot.findSlot(92);
+        Slot slot = J1939DaRepository.findSlot(92);
         byte[] data = { (byte) 0xA5 };
         assertEquals("0100101", slot.asString(data));
         assertFalse(slot.isNotAvailable(data));
@@ -366,7 +367,7 @@ public class SlotTest {
 
     @Test
     public void test7BytesASCII() {
-        Slot slot = Slot.findSlot(110);
+        Slot slot = J1939DaRepository.findSlot(110);
         byte[] data = "1234567".getBytes();
         assertEquals("1234567", slot.asString(data));
         assertFalse(slot.isNotAvailable(data));
@@ -375,7 +376,7 @@ public class SlotTest {
 
     @Test
     public void test8Bits() {
-        Slot slot = Slot.findSlot(93);
+        Slot slot = J1939DaRepository.findSlot(93);
         byte[] data = { (byte) 0xA5 };
         assertEquals("10100101", slot.asString(data));
         assertFalse(slot.isNotAvailable(data));
@@ -394,7 +395,7 @@ public class SlotTest {
 
     @Test
     public void testConvert5Bits() {
-        Slot slot = Slot.findSlot(292);
+        Slot slot = J1939DaRepository.findSlot(292);
         byte[] data = { (byte) 0xA5 };
         assertEquals("00101", slot.asString(data));
         assertFalse(slot.isNotAvailable(data));
@@ -413,7 +414,7 @@ public class SlotTest {
 
     @Test
     public void testNonDelimitedASCII() {
-        Slot slot = Slot.findSlot(228);
+        Slot slot = J1939DaRepository.findSlot(228);
 
         byte[] data = { 0x41, 0x42, 0x43, 0x44, 0x45, 0x51, 0x52, '*' };
         assertEquals("ABCDEQR*", slot.asString(data));
@@ -423,7 +424,7 @@ public class SlotTest {
 
     @Test
     public void testNullDelimitedASCII() {
-        Slot slot = Slot.findSlot(258);
+        Slot slot = J1939DaRepository.findSlot(258);
 
         byte[] data = { 0x41, 0x42, 0x43, 0x44, 0x45, 0x00, 0x51, 0x52 };
         assertEquals("ABCDE", slot.asString(data));
@@ -433,7 +434,7 @@ public class SlotTest {
 
     @Test
     public void testSlotNoScaleNoOffset() {
-        Slot slot = Slot.findSlot(41);
+        Slot slot = J1939DaRepository.findSlot(41);
         assertNotNull(slot);
         assertEquals(41, slot.getId());
         assertEquals("SAEec03", slot.getName());
@@ -447,7 +448,7 @@ public class SlotTest {
 
     @Test
     public void testSlotNoScaleWithOffset() {
-        Slot slot = Slot.findSlot(5);
+        Slot slot = J1939DaRepository.findSlot(5);
         assertNotNull(slot);
         assertEquals(5, slot.getId());
         assertEquals("SAEtm12", slot.getName());
@@ -461,7 +462,7 @@ public class SlotTest {
 
     @Test
     public void testSlotWithPartScale() {
-        Slot slot = Slot.findSlot(39);
+        Slot slot = J1939DaRepository.findSlot(39);
         assertNotNull(slot);
         assertEquals(39, slot.getId());
         assertEquals("SAEds06", slot.getName());
@@ -475,7 +476,7 @@ public class SlotTest {
 
     @Test
     public void testSlotWithPositiveOffset() {
-        Slot slot = Slot.findSlot(284);
+        Slot slot = J1939DaRepository.findSlot(284);
         assertNotNull(slot);
         assertEquals(284, slot.getId());
         assertEquals("SAEcy02", slot.getName());
@@ -489,7 +490,7 @@ public class SlotTest {
 
     @Test
     public void testSlotWithScaleNoOffset() {
-        Slot slot = Slot.findSlot(1);
+        Slot slot = J1939DaRepository.findSlot(1);
         assertNotNull(slot);
         assertEquals(1, slot.getId());
         assertEquals("SAEpr11", slot.getName());
@@ -503,7 +504,7 @@ public class SlotTest {
 
     @Test
     public void testSlotWithWholeScaleWithWholeOffset() {
-        Slot slot = Slot.findSlot(127);
+        Slot slot = J1939DaRepository.findSlot(127);
         assertNotNull(slot);
         assertEquals(127, slot.getId());
         assertEquals("SAEfr02", slot.getName());
@@ -517,7 +518,7 @@ public class SlotTest {
 
     @Test
     public void testStarDelimitedASCII() {
-        Slot slot = Slot.findSlot(108);
+        Slot slot = J1939DaRepository.findSlot(108);
         byte[] data = "1234567890*ASDFGHJKL".getBytes();
         assertEquals("1234567890", slot.asString(data));
         assertFalse(slot.isNotAvailable(data));
@@ -526,12 +527,12 @@ public class SlotTest {
 
     @Test
     public void verifySpecialCharacters() {
-        assertEquals("km²/h²", Slot.findSlot(469).getUnit());
-        assertEquals("m/s²", Slot.findSlot(140).getUnit());
-        assertEquals("(kPa•s)/m³", Slot.findSlot(359).getUnit());
-        assertEquals("µSiemens/mm", Slot.findSlot(255).getUnit());
-        assertEquals("MJ/Nm³", Slot.findSlot(323).getUnit());
-        assertEquals("µA", Slot.findSlot(403).getUnit());
+        assertEquals("km²/h²", J1939DaRepository.findSlot(469).getUnit());
+        assertEquals("m/s²", J1939DaRepository.findSlot(140).getUnit());
+        assertEquals("(kPa•s)/m³", J1939DaRepository.findSlot(359).getUnit());
+        assertEquals("µSiemens/mm", J1939DaRepository.findSlot(255).getUnit());
+        assertEquals("MJ/Nm³", J1939DaRepository.findSlot(323).getUnit());
+        assertEquals("µA", J1939DaRepository.findSlot(403).getUnit());
 
     }
 

--- a/src-test/org/etools/j1939_84/controllers/FreezeFrameDataTranslatorTest.java
+++ b/src-test/org/etools/j1939_84/controllers/FreezeFrameDataTranslatorTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2021. Equipment & Tool Institute
+ */
+
+package org.etools.j1939_84.controllers;
+
+import static org.etools.j1939_84.J1939_84.NL;
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import org.etools.j1939_84.bus.Packet;
+import org.etools.j1939_84.bus.j1939.packets.DM24SPNSupportPacket;
+import org.etools.j1939_84.bus.j1939.packets.DM25ExpandedFreezeFrame;
+import org.etools.j1939_84.bus.j1939.packets.FreezeFrame;
+import org.etools.j1939_84.bus.j1939.packets.SupportedSPN;
+import org.etools.j1939_84.bus.j1939.packets.model.Spn;
+import org.junit.Before;
+import org.junit.Test;
+
+public class FreezeFrameDataTranslatorTest {
+
+    private FreezeFrameDataTranslator instance;
+
+    @Before
+    public void setUp() {
+        instance = new FreezeFrameDataTranslator();
+    }
+
+    @Test
+    public void testGetFreezeFrameSPNs() {
+        List<FreezeFrame> freezeFrames = createDM25().getFreezeFrames();
+
+        FreezeFrame freezeFrame = freezeFrames.get(0);
+
+        List<SupportedSPN> supportedSPNs = createDM24().getFreezeFrameSPNsInOrder();
+
+        List<Spn> spns = instance.getFreezeFrameSPNs(freezeFrame, supportedSPNs);
+
+        freezeFrame.setSPNs(spns);
+
+        String expected = "";
+        expected += "Freeze Frame: {" + NL;
+        expected += "DTC 102:4 - Engine Intake Manifold #1 Pressure, Voltage Below Normal, Or Shorted To Low Source - 1 times" + NL;
+        expected += "SPN Data: 19 F8 4D 84 82 02 31 A7 C6 24 CB 00 0A 20 4E B3 3B E0 01 04 73 A2 04 7D A5 09 15 01 62 A9 25 7C 29 54 14 B6 2D A0 64 0F 3C 00 00 56 00 FF FF A0 0F 01 00 04 00 D6 2C 02 00 40 2E 1F 1A 00 C6 02 00 00 C0 AF 80 25 96 25 73 2B B9 2D 76 09 0B 00 86 29 AF 30 00 00 00 D7 52 09 58 34 C0 2B 20 1C 3A 41 D3 E1 DF 8C C1 E5 61 00 00 00 9E 15 01 FF FF FF FF FF FF 1F 50 14" + NL;
+        expected += "SPN    91, Accelerator Pedal Position 1: 10.000000 %" + NL;
+        expected += "SPN    27, Engine EGR 1 Valve Position: 49.900000 %" + NL;
+        expected += "SPN   513, Actual Engine - Percent Torque: 7.000000 %" + NL;
+        expected += "SPN   132, Engine Intake Air Mass Flow Rate: 32.100000 kg/h" + NL;
+        expected += "SPN  3217, Engine Exhaust 1 Percent Oxygen 1: 9.999714 %" + NL;
+        expected += "SPN   171, Ambient Air Temperature: 21.187500 °C" + NL;
+        expected += "SPN   108, Barometric Pressure: 101.500000 kPa" + NL;
+        expected += "SPN   102, Engine Intake Manifold #1 Pressure: 0.000000 kPa" + NL;
+        expected += "SPN    92, Engine Percent Load At Current Speed: 10.000000 %" + NL;
+        expected += "SPN  2791, Engine EGR 1 Valve 1 Control 1: 50.000000 %" + NL;
+        expected += "SPN  5313, Commanded Engine Fuel Rail Pressure: 59.699219 MPa" + NL;
+        expected += "SPN  5833, Engine Fuel Mass Flow Rate: 2.400000 g/s" + NL;
+        expected += "SPN  5837, Fuel Type: 00000100" + NL;
+        expected += "SPN   641, Engine Variable Geometry Turbocharger Actuator #1: 46.000000 %" + NL;
+        expected += "SPN  1692, Engine Intake Manifold Desired Absolute Pressure: 118.600000 kPa" + NL;
+        expected += "SPN   512, Driver's Demand Engine - Percent Torque: 0.000000 %" + NL;
+        expected += "SPN  2659, Engine EGR 1 Mass Flow Rate: 123.450000 kg/h" + NL;
+        expected += "SPN   168, Battery Potential / Power Input 1: 13.850000 V" + NL;
+        expected += "SPN   110, Engine Coolant Temperature: 58.000000 °C" + NL;
+        expected += "SPN  2630, Engine Charge Air Cooler 1 Outlet Temperature: 28.281250 °C" + NL;
+        expected += "SPN   175, Engine Oil Temperature 1: 58.875000 °C" + NL;
+        expected += "SPN   190, Engine Speed: 650.500000 rpm" + NL;
+        expected += "SPN   173, Engine Exhaust Temperature: 92.687500 °C" + NL;
+        expected += "SPN  1436, Engine Actual Ignition Timing: 1.250000 deg" + NL;
+        expected += "SPN   157, Engine Fuel 1 Injector Metering Rail 1 Pressure: 60.058594 MPa" + NL;
+        expected += "SPN  1440, Engine Fuel Flow Rate 1: 0.000000 m³/h" + NL;
+        expected += "SPN   105, Engine Intake Manifold 1 Temperature: 46.000000 °C" + NL;
+        expected += "SPN  3563, Engine Intake Manifold #1 Absolute Pressure: 0.000000 kPa" + NL;
+        expected += "SPN  3226, AFT 1 Outlet NOx 1: Not Available" + NL;
+        expected += "SPN  3216, Engine Exhaust 1 NOx 1: 0.000000 ppm" + NL;
+        expected += "SPN  3251, AFT 1 DPF Differential Pressure: 0.100000 kPa" + NL;
+        expected += "SPN  3609, AFT 1 DPF Intake Pressure: 0.400000 kPa" + NL;
+        expected += "SPN  4766, AFT 1 Diesel Oxidation Catalyst Outlet Temperature: 85.687500 °C" + NL;
+        expected += "SPN  3610, AFT 1 DPF Outlet Pressure: 0.200000 kPa" + NL;
+        expected += "SPN  3246, AFT 1 DPF Outlet Temperature: 97.000000 °C" + NL;
+        expected += "SPN   976, PTO Governor State: 11111" + NL;
+        expected += "SPN  3301, Time Since Engine Start: 26.000000" + NL;
+        expected += "SPN   247, Engine Total Hours of Operation: 35.500000 h" + NL;
+        expected += "SPN  1176, Engine Turbocharger 1 Compressor Intake Pressure: 101.500000 kPa" + NL;
+        expected += "SPN  1172, Engine Turbocharger 1 Compressor Intake Temperature: 27.000000 °C" + NL;
+        expected += "SPN  2629, Engine Turbocharger 1 Compressor Outlet Temperature: 27.687500 °C" + NL;
+        expected += "SPN  1180, Engine Turbocharger 1 Turbine Intake Temperature: 74.593750 °C" + NL;
+        expected += "SPN  1184, Engine Turbocharger 1 Turbine Outlet Temperature: 92.781250 °C" + NL;
+        expected += "SPN   103, Engine Turbocharger 1 Speed: 9688.000000 rpm" + NL;
+        expected += "SPN  2795, Engine Variable Geometry Turbocharger (VGT) 1 Actuator Position: 4.400000 %" + NL;
+        expected += "SPN  3490, AFT 1 Purge Air Actuator: 00" + NL;
+        expected += "SPN   412, Engine EGR 1 Temperature: 59.187500 °C" + NL;
+        expected += "SPN    94, Engine Fuel Delivery Pressure: 700.000000 kPa" + NL;
+        expected += "SPN   183, Engine Fuel Rate: 2.400000 l/h" + NL;
+        expected += "SPN  1081, Engine Wait to Start Lamp: 00" + NL;
+        expected += "SPN  3700, AFT DPF Active Regeneration Status: 00" + NL;
+        expected += "SPN  1761, AFT 1 DEF Tank Volume: 86.000000 %" + NL;
+        expected += "SPN   544, Engine Reference Torque: 2386.000000 Nm" + NL;
+        expected += "SPN   531, Engine Speed At Point 5: 1675.000000 rpm" + NL;
+        expected += "SPN   530, Engine Speed At Point 4: 1400.000000 rpm" + NL;
+        expected += "SPN   529, Engine Speed At Point 3: 900.000000 rpm" + NL;
+        expected += "SPN   528, Engine Speed At Point 2: 2087.250000 rpm" + NL;
+        expected += "SPN   543, Engine Percent Torque At Point 5: 86.000000 %" + NL;
+        expected += "SPN   542, Engine Percent Torque At Point 4: 100.000000 %" + NL;
+        expected += "SPN   541, Engine Percent Torque At Point 3: 98.000000 %" + NL;
+        expected += "SPN   540, Engine Percent Torque At Point 2: 15.000000 %" + NL;
+        expected += "SPN   539, Engine Percent Torque At Idle, Point 1: 68.000000 %" + NL;
+        expected += "SPN  5466, AFT 1 DPF Soot Load Regeneration Threshold: 62.652500 %" + NL;
+        expected += "SPN    84, Wheel-Based Vehicle Speed: 0.000000 km/h" + NL;
+        expected += "SPN  5457, Engine Variable Geometry Turbocharger 1 Control Mode: 00" + NL;
+        expected += "SPN    96, Fuel Level 1: 63.200000 %" + NL;
+        expected += "SPN   158, Key Switch Battery Potential: 13.850000 V" + NL;
+        expected += "SPN  3523, AFT 1 Total Regeneration Time: Not Available" + NL;
+        expected += "SPN  7351, AFT 1 Outlet Corrected NOx: Not Available" + NL;
+        expected += "SPN   106, Engine Intake Air Pressure: 62.000000 kPa" + NL;
+        expected += "SPN   188, Engine Speed At Idle, Point 1: 650.000000 rpm" + NL;
+        expected += "}";
+        assertEquals(expected, freezeFrame.toString());
+    }
+
+    private static DM24SPNSupportPacket createDM24() {
+        return DM24SPNSupportPacket.create(0,
+                                           SupportedSPN.create(91, true, true, true, 1),
+                                           SupportedSPN.create(27, true, true, true, 2),
+                                           SupportedSPN.create(513, true, true, true, 1),
+                                           SupportedSPN.create(132, true, true, true, 2),
+                                           SupportedSPN.create(3217, true, true, true, 2),
+                                           SupportedSPN.create(171, true, true, true, 2),
+                                           SupportedSPN.create(108, true, true, true, 1),
+                                           SupportedSPN.create(102, true, true, true, 1),
+                                           SupportedSPN.create(92, true, true, true, 1),
+                                           SupportedSPN.create(2791, true, true, true, 2),
+                                           SupportedSPN.create(5313, true, true, true, 2),
+                                           SupportedSPN.create(5833, true, true, true, 2),
+                                           SupportedSPN.create(5837, true, true, true, 1),
+                                           SupportedSPN.create(641, true, true, true, 1),
+                                           SupportedSPN.create(1692, true, true, true, 2),
+                                           SupportedSPN.create(512, true, true, true, 1),
+                                           SupportedSPN.create(2659, true, true, true, 2),
+                                           SupportedSPN.create(168, true, true, true, 2),
+                                           SupportedSPN.create(110, true, true, true, 1),
+                                           SupportedSPN.create(2630, true, true, true, 2),
+                                           SupportedSPN.create(175, true, true, true, 2),
+                                           SupportedSPN.create(190, true, true, true, 2),
+                                           SupportedSPN.create(173, true, true, true, 2),
+                                           SupportedSPN.create(1436, true, true, true, 2),
+                                           SupportedSPN.create(157, true, true, true, 2),
+                                           SupportedSPN.create(1440, true, true, true, 2),
+                                           SupportedSPN.create(105, true, true, true, 1),
+                                           SupportedSPN.create(3563, true, true, true, 1),
+                                           SupportedSPN.create(3226, true, true, true, 2),
+                                           SupportedSPN.create(3216, true, true, true, 2),
+                                           SupportedSPN.create(3251, true, true, true, 2),
+                                           SupportedSPN.create(3609, true, true, true, 2),
+                                           SupportedSPN.create(4766, true, true, true, 2),
+                                           SupportedSPN.create(3610, true, true, true, 2),
+                                           SupportedSPN.create(3246, true, true, true, 2),
+                                           SupportedSPN.create(976, true, true, true, 1),
+                                           SupportedSPN.create(3301, true, true, true, 2),
+                                           SupportedSPN.create(247, true, true, true, 4),
+                                           SupportedSPN.create(1176, true, true, true, 2),
+                                           SupportedSPN.create(1172, true, true, true, 2),
+                                           SupportedSPN.create(2629, true, true, true, 2),
+                                           SupportedSPN.create(1180, true, true, true, 2),
+                                           SupportedSPN.create(1184, true, true, true, 2),
+                                           SupportedSPN.create(103, true, true, true, 2),
+                                           SupportedSPN.create(2795, true, true, true, 1),
+                                           SupportedSPN.create(3490, true, true, true, 1),
+                                           SupportedSPN.create(412, true, true, true, 2),
+                                           SupportedSPN.create(94, true, true, true, 1),
+                                           SupportedSPN.create(183, true, true, true, 2),
+                                           SupportedSPN.create(1081, true, true, true, 1),
+                                           SupportedSPN.create(3700, true, true, true, 1),
+                                           SupportedSPN.create(1761, true, true, true, 1),
+                                           SupportedSPN.create(544, true, true, true, 2),
+                                           SupportedSPN.create(531, true, true, true, 2),
+                                           SupportedSPN.create(530, true, true, true, 2),
+                                           SupportedSPN.create(529, true, true, true, 2),
+                                           SupportedSPN.create(528, true, true, true, 2),
+                                           SupportedSPN.create(543, true, true, true, 1),
+                                           SupportedSPN.create(542, true, true, true, 1),
+                                           SupportedSPN.create(541, true, true, true, 1),
+                                           SupportedSPN.create(540, true, true, true, 1),
+                                           SupportedSPN.create(539, true, true, true, 1),
+                                           SupportedSPN.create(5466, true, true, true, 2),
+                                           SupportedSPN.create(84, true, true, true, 2),
+                                           SupportedSPN.create(5457, true, true, true, 1),
+                                           SupportedSPN.create(96, true, true, true, 1),
+                                           SupportedSPN.create(158, true, true, true, 2),
+                                           SupportedSPN.create(3523, true, true, true, 4),
+                                           SupportedSPN.create(7351, true, true, true, 2),
+                                           SupportedSPN.create(106, true, true, true, 1),
+                                           SupportedSPN.create(188, true, true, true, 2));
+    }
+
+    private static DM25ExpandedFreezeFrame createDM25() {
+        //@formatter:off
+        int[] data = {
+                0x7C, 0x66, 0x00, 0x04, 0x01, 0x19, 0xF8, 0x4D, 0x84, 0x82, 0x02, 0x31, 0xA7, 0xC6, 0x24, 0xCB, 0x00,
+                0x0A, 0x20, 0x4E, 0xB3, 0x3B, 0xE0, 0x01, 0x04, 0x73, 0xA2, 0x04, 0x7D, 0xA5, 0x09, 0x15, 0x01, 0x62,
+                0xA9, 0x25, 0x7C, 0x29, 0x54, 0x14, 0xB6, 0x2D, 0xA0, 0x64, 0x0F, 0x3C, 0x00, 0x00, 0x56, 0x00, 0xFF,
+                0xFF, 0xA0, 0x0F, 0x01, 0x00, 0x04, 0x00, 0xD6, 0x2C, 0x02, 0x00, 0x40, 0x2E, 0x1F, 0x1A, 0x00, 0xC6,
+                0x02, 0x00, 0x00, 0xC0, 0xAF, 0x80, 0x25, 0x96, 0x25, 0x73, 0x2B, 0xB9, 0x2D, 0x76, 0x09, 0x0B, 0x00,
+                0x86, 0x29, 0xAF, 0x30, 0x00, 0x00, 0x00, 0xD7, 0x52, 0x09, 0x58, 0x34, 0xC0, 0x2B, 0x20, 0x1C, 0x3A,
+                0x41, 0xD3, 0xE1, 0xDF, 0x8C, 0xC1, 0xE5, 0x61, 0x00, 0x00, 0x00, 0x9E, 0x15, 0x01, 0xFF, 0xFF, 0xFF,
+                0xFF, 0xFF, 0xFF, 0x1F, 0x50, 0x14
+        };
+        //@formatter:on
+        return new DM25ExpandedFreezeFrame(Packet.create(DM25ExpandedFreezeFrame.PGN, 0, data));
+    }
+
+}

--- a/src-test/org/etools/j1939_84/controllers/TableA2ValueValidatorTest.java
+++ b/src-test/org/etools/j1939_84/controllers/TableA2ValueValidatorTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2021. Equipment & Tool Institute
+ */
+
+package org.etools.j1939_84.controllers;
+
+import static org.etools.j1939_84.J1939_84.NL;
+import static org.etools.j1939_84.model.Outcome.WARN;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.util.List;
+import org.etools.j1939_84.bus.j1939.packets.DiagnosticTroubleCode;
+import org.etools.j1939_84.bus.j1939.packets.FreezeFrame;
+import org.etools.j1939_84.bus.j1939.packets.model.Spn;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TableA2ValueValidatorTest {
+
+    @Mock
+    private ResultsListener mockListener;
+
+    private TestResultsListener listener;
+
+    private TableA2ValueValidator instance;
+
+    @Before
+    public void setUp() throws Exception {
+        listener = new TestResultsListener(mockListener);
+        instance = new TableA2ValueValidator(1, 2);
+    }
+
+    @After
+    public void tearDown() {
+        verifyNoMoreInteractions(mockListener);
+    }
+
+    @Test
+    public void reportWarningsNoMessages() {
+        DiagnosticTroubleCode dtc = DiagnosticTroubleCode.create(123, 14, 1, 1);
+
+        List<Spn> spns = List.of(Spn.create(92, 1),
+                                 Spn.create(110, 7),
+                                 Spn.create(1637, 8),
+                                 Spn.create(4076, 109),
+                                 Spn.create(4193, 110),
+                                 Spn.create(190, 301),
+                                 Spn.create(4201, 1024),
+                                 Spn.create(723, 327),
+                                 Spn.create(4202, 2024),
+                                 Spn.create(512, 0),
+                                 Spn.create(513, 1),
+                                 Spn.create(3301, 1),
+                                 Spn.create(514,1));
+        FreezeFrame freezeFrame = new FreezeFrame(dtc, spns);
+        freezeFrame.setSPNs(spns);
+
+        instance.reportWarnings(freezeFrame, listener, "6.1.2");
+
+        assertEquals("", listener.getResults());
+    }
+
+    @Test
+    public void reportWarningsAllFailed() {
+        DiagnosticTroubleCode dtc = DiagnosticTroubleCode.create(123, 14, 1, 1);
+        List<Spn> spns = List.of(Spn.create(92, 0),
+                                 Spn.create(110, 6),
+                                 Spn.create(1637, 6),
+                                 Spn.create(4076, 111),
+                                 Spn.create(4193, 111),
+                                 Spn.create(190, 301),
+                                 Spn.create(4201, 299),
+                                 Spn.create(723, 1),
+                                 Spn.create(4202, 0),
+                                 Spn.create(512, -1),
+                                 Spn.create(513, 0),
+                                 Spn.create(3301, 0));
+        FreezeFrame freezeFrame = new FreezeFrame(dtc, spns);
+        freezeFrame.setSPNs(spns);
+
+        instance.reportWarnings(freezeFrame, listener, "6.1.2");
+
+        String expected = "";
+        expected += "WARN: SPN   110, Engine Coolant Temperature: 6.000000 °C is < 7 C or > 110 C" + NL;
+        expected += "WARN: SPN  1637, Engine Coolant Temperature (High Resolution): 6.000000 °C is < 7 C or > 110 C" + NL;
+        expected += "WARN: SPN  4076, Engine Coolant Temperature 2: 111.000000 °C is < 7 C or > 110 C" + NL;
+        expected += "WARN: SPN  4193, Engine Coolant Pump Outlet Temperature: 111.000000 °C is < 7 C or > 110 C" + NL;
+        expected += "WARN: SPN  4201, Engine Speed 1: 299.000000 rpm is <= 300 rpm" + NL;
+        expected += "WARN: SPN   723, Engine Speed 2: 1.000000 rpm is <= 300 rpm" + NL;
+        expected += "WARN: SPN  4202, Engine Speed 3: 0.000000 rpm is <= 300 rpm" + NL;
+        expected += "WARN: SPN    92, Engine Percent Load At Current Speed: 0.000000 % is <= 0% with rpm > 300" + NL;
+        expected += "WARN: SPN   512, Driver's Demand Engine - Percent Torque: -1.000000 % is < 0% with rpm > 300" + NL;
+        expected += "WARN: SPN   513, Actual Engine - Percent Torque: 0.000000 % is <= 0% with rpm > 300" + NL;
+        expected += "WARN: SPN  3301, Time Since Engine Start: 0.000000 is = 0 seconds with rpm > 300" + NL;
+
+        assertEquals(expected, listener.getResults());
+
+        verify(mockListener).addOutcome(1,
+                                        2,
+                                        WARN,
+                                        "6.1.2 - SPN   110, Engine Coolant Temperature: 6.000000 °C is < 7 C or > 110 C");
+        verify(mockListener).addOutcome(1,
+                                        2,
+                                        WARN,
+                                        "6.1.2 - SPN  1637, Engine Coolant Temperature (High Resolution): 6.000000 °C is < 7 C or > 110 C");
+        verify(mockListener).addOutcome(1,
+                                        2,
+                                        WARN,
+                                        "6.1.2 - SPN  4076, Engine Coolant Temperature 2: 111.000000 °C is < 7 C or > 110 C");
+        verify(mockListener).addOutcome(1,
+                                        2,
+                                        WARN,
+                                        "6.1.2 - SPN  4193, Engine Coolant Pump Outlet Temperature: 111.000000 °C is < 7 C or > 110 C");
+        verify(mockListener).addOutcome(1, 2, WARN, "6.1.2 - SPN  4201, Engine Speed 1: 299.000000 rpm is <= 300 rpm");
+        verify(mockListener).addOutcome(1, 2, WARN, "6.1.2 - SPN   723, Engine Speed 2: 1.000000 rpm is <= 300 rpm");
+        verify(mockListener).addOutcome(1, 2, WARN, "6.1.2 - SPN  4202, Engine Speed 3: 0.000000 rpm is <= 300 rpm");
+        verify(mockListener).addOutcome(1,
+                                        2,
+                                        WARN,
+                                        "6.1.2 - SPN    92, Engine Percent Load At Current Speed: 0.000000 % is <= 0% with rpm > 300");
+        verify(mockListener).addOutcome(1,
+                                        2,
+                                        WARN,
+                                        "6.1.2 - SPN   512, Driver's Demand Engine - Percent Torque: -1.000000 % is < 0% with rpm > 300");
+        verify(mockListener).addOutcome(1,
+                                        2,
+                                        WARN,
+                                        "6.1.2 - SPN   513, Actual Engine - Percent Torque: 0.000000 % is <= 0% with rpm > 300");
+        verify(mockListener).addOutcome(1,
+                                        2,
+                                        WARN,
+                                        "6.1.2 - SPN  3301, Time Since Engine Start: 0.000000 is = 0 seconds with rpm > 300");
+    }
+
+    @Test
+    public void reportWarningsNoEngineSpeed() {
+        DiagnosticTroubleCode dtc = DiagnosticTroubleCode.create(123, 14, 1, 1);
+
+        List<Spn> spns = List.of(Spn.create(92, 0),
+                                 Spn.create(110, 10),
+                                 Spn.create(1637, 10),
+                                 Spn.create(4076, 10),
+                                 Spn.create(4193, 10),
+                                 Spn.create(190, (0xFFFF * 0.125)),
+                                 Spn.create(4201, (0xFF00 * 0.5)),
+                                 Spn.create(723, (0xFEFF * 0.5)),
+                                 Spn.create(4202, (0xFE00 * 0.5)),
+                                 Spn.create(512, -1),
+                                 Spn.create(513, 0),
+                                 Spn.create(3301, 0));
+        FreezeFrame freezeFrame = new FreezeFrame(dtc, spns);
+        freezeFrame.setSPNs(spns);
+
+        instance.reportWarnings(freezeFrame, listener, "6.1.2");
+
+        assertEquals("Unable to confirm engine speed" + NL, listener.getResults());
+    }
+
+}

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step12ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step12ControllerTest.java
@@ -22,9 +22,9 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import org.etools.j1939_84.bus.j1939.J1939;
+import org.etools.j1939_84.bus.j1939.J1939DaRepository;
 import org.etools.j1939_84.bus.j1939.packets.DM30ScaledTestResultsPacket;
 import org.etools.j1939_84.bus.j1939.packets.ScaledTestResult;
-import org.etools.j1939_84.bus.j1939.packets.Slot;
 import org.etools.j1939_84.bus.j1939.packets.SupportedSPN;
 import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.ResultsListener;
@@ -34,8 +34,8 @@ import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.VehicleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 import org.etools.j1939_84.utils.AbstractControllerTest;
@@ -112,7 +112,7 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
                                               tableA7Validator,
                                               DateTimeModule.getInstance());
 
-        setup(instance, listener, j1939, engineSpeedModule, reportFileModule, executor, vehicleInformationModule);
+        setup(instance, listener, j1939, executor, reportFileModule, engineSpeedModule, vehicleInformationModule, diagnosticMessageModule);
     }
 
     @After
@@ -151,7 +151,7 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
         scaledTestsResults.add(scaledTestResult2);
         when(scaledTestResult2.getSpn()).thenReturn(159);
         int slotNumber2 = 8;
-        when(scaledTestResult2.getSlot()).thenReturn(Slot.findSlot(slotNumber2));
+        when(scaledTestResult2.getSlot()).thenReturn(J1939DaRepository.findSlot(slotNumber2));
 
         List<DM30ScaledTestResultsPacket> dm30Packets = new ArrayList<>();
         DM30ScaledTestResultsPacket dm30Packet = mock(DM30ScaledTestResultsPacket.class);
@@ -205,7 +205,7 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
         scaledTestsResults.add(scaledTestResult2);
         when(scaledTestResult2.getSpn()).thenReturn(159);
         int slotNumber2 = 8;
-        when(scaledTestResult2.getSlot()).thenReturn(Slot.findSlot(slotNumber2));
+        when(scaledTestResult2.getSlot()).thenReturn(J1939DaRepository.findSlot(slotNumber2));
 
         List<DM30ScaledTestResultsPacket> dm30Packets = new ArrayList<>();
         DM30ScaledTestResultsPacket dm30Packet = mock(DM30ScaledTestResultsPacket.class);
@@ -309,7 +309,7 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
         ScaledTestResult scaledTestResult = mock(ScaledTestResult.class);
         scaledTestsResults.add(scaledTestResult);
         when(scaledTestResult.getSpn()).thenReturn(157);
-        when(scaledTestResult.getSlot()).thenReturn(Slot.findSlot(242));
+        when(scaledTestResult.getSlot()).thenReturn(J1939DaRepository.findSlot(242));
         when(scaledTestResult.getTestMaximum()).thenReturn(0x0000);
         when(scaledTestResult.getTestMinimum()).thenReturn(0x0000);
         when(scaledTestResult.getTestValue()).thenReturn(0x0000);
@@ -356,7 +356,7 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
         scaledTestsResults.add(scaledTestResult);
         when(scaledTestResult.getTestMaximum()).thenReturn(0x88);
         when(scaledTestResult.getSpn()).thenReturn(157);
-        when(scaledTestResult.getSlot()).thenReturn(Slot.findSlot(242));
+        when(scaledTestResult.getSlot()).thenReturn(J1939DaRepository.findSlot(242));
 
         List<DM30ScaledTestResultsPacket> dm30Packets = new ArrayList<>();
         DM30ScaledTestResultsPacket dm30Packet = mock(DM30ScaledTestResultsPacket.class);
@@ -414,7 +414,7 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
         when(scaledTestResult.getTestValue()).thenReturn(0xFB00);
         when(scaledTestResult.getTestMinimum()).thenReturn(0x88);
         when(scaledTestResult.getSpn()).thenReturn(157);
-        when(scaledTestResult.getSlot()).thenReturn(Slot.findSlot(242));
+        when(scaledTestResult.getSlot()).thenReturn(J1939DaRepository.findSlot(242));
 
         List<DM30ScaledTestResultsPacket> dm30Packets = new ArrayList<>();
         DM30ScaledTestResultsPacket dm30Packet = mock(DM30ScaledTestResultsPacket.class);
@@ -469,7 +469,7 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
         scaledTestsResults.add(scaledTestResult);
         when(scaledTestResult.getTestValue()).thenReturn(0x25);
         when(scaledTestResult.getSpn()).thenReturn(157);
-        when(scaledTestResult.getSlot()).thenReturn(Slot.findSlot(242));
+        when(scaledTestResult.getSlot()).thenReturn(J1939DaRepository.findSlot(242));
 
         List<DM30ScaledTestResultsPacket> dm30Packets = new ArrayList<>();
         DM30ScaledTestResultsPacket dm30Packet = mock(DM30ScaledTestResultsPacket.class);
@@ -533,7 +533,7 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
         scaledTestsResults.add(scaledTestResult);
 
         int slotNumber = 1;
-        when(scaledTestResult.getSlot()).thenReturn(Slot.findSlot(slotNumber));
+        when(scaledTestResult.getSlot()).thenReturn(J1939DaRepository.findSlot(slotNumber));
 
         List<DM30ScaledTestResultsPacket> dm30Packets = new ArrayList<>();
         DM30ScaledTestResultsPacket dm30Packet = mock(DM30ScaledTestResultsPacket.class);
@@ -610,7 +610,7 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
         ScaledTestResult scaledTestResult = mock(ScaledTestResult.class);
         scaledTestsResults.add(scaledTestResult);
         when(scaledTestResult.getSpn()).thenReturn(157);
-        when(scaledTestResult.getSlot()).thenReturn(Slot.findSlot(242));
+        when(scaledTestResult.getSlot()).thenReturn(J1939DaRepository.findSlot(242));
 
         List<DM30ScaledTestResultsPacket> dm30Packets = new ArrayList<>();
         DM30ScaledTestResultsPacket dm30Packet = mock(DM30ScaledTestResultsPacket.class);
@@ -661,14 +661,14 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
         when(scaledTestResult.getTestMinimum()).thenReturn(0xFB00);
         when(scaledTestResult.getSpn()).thenReturn(157);
         when(scaledTestResult.getFmi()).thenReturn(18);
-        when(scaledTestResult.getSlot()).thenReturn(Slot.findSlot(242));
+        when(scaledTestResult.getSlot()).thenReturn(J1939DaRepository.findSlot(242));
         ScaledTestResult scaledTestResult2 = mock(ScaledTestResult.class);
         scaledTestsResults.add(scaledTestResult2);
         when(scaledTestResult2.getTestValue()).thenReturn(0xFB00);
         when(scaledTestResult2.getTestMinimum()).thenReturn(0xFFFF);
         when(scaledTestResult2.getTestMaximum()).thenReturn(0xFF00);
         when(scaledTestResult2.getSpn()).thenReturn(157);
-        when(scaledTestResult2.getSlot()).thenReturn(Slot.findSlot(242));
+        when(scaledTestResult2.getSlot()).thenReturn(J1939DaRepository.findSlot(242));
 
         List<DM30ScaledTestResultsPacket> dm30Packets = new ArrayList<>();
         DM30ScaledTestResultsPacket dm30Packet = mock(DM30ScaledTestResultsPacket.class);
@@ -739,7 +739,7 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
         scaledTestsResults.add(scaledTestResult2);
         when(scaledTestResult2.getSpn()).thenReturn(159);
         int slotNumber2 = 8;
-        when(scaledTestResult2.getSlot()).thenReturn(Slot.findSlot(slotNumber2));
+        when(scaledTestResult2.getSlot()).thenReturn(J1939DaRepository.findSlot(slotNumber2));
 
         List<DM30ScaledTestResultsPacket> dm30Packets = new ArrayList<>();
         DM30ScaledTestResultsPacket dm30Packet = mock(DM30ScaledTestResultsPacket.class);

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step24ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step24ControllerTest.java
@@ -13,11 +13,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import java.util.List;
 import java.util.concurrent.Executor;
 import org.etools.j1939_84.bus.Packet;
 import org.etools.j1939_84.bus.j1939.BusResult;
 import org.etools.j1939_84.bus.j1939.J1939;
+import org.etools.j1939_84.bus.j1939.packets.DM24SPNSupportPacket;
 import org.etools.j1939_84.bus.j1939.packets.DM25ExpandedFreezeFrame;
 import org.etools.j1939_84.bus.j1939.packets.SupportedSPN;
 import org.etools.j1939_84.controllers.DataRepository;
@@ -25,8 +25,8 @@ import org.etools.j1939_84.controllers.ResultsListener;
 import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
 import org.etools.j1939_84.modules.DateTimeModule;
+import org.etools.j1939_84.modules.DiagnosticMessageModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -93,7 +93,14 @@ public class Part01Step24ControllerTest extends AbstractControllerTest {
                                               dataRepository,
                                               DateTimeModule.getInstance());
 
-        setup(instance, listener, j1939, engineSpeedModule, reportFileModule, executor, vehicleInformationModule);
+        setup(instance,
+              listener,
+              j1939,
+              executor,
+              reportFileModule,
+              engineSpeedModule,
+              vehicleInformationModule,
+              diagnosticMessageModule);
     }
 
     @After
@@ -142,12 +149,11 @@ public class Part01Step24ControllerTest extends AbstractControllerTest {
         when(diagnosticMessageModule.requestDM25(any(), eq(0x00))).thenReturn(new BusResult<>(false, packet));
 
         OBDModuleInformation obdInfo = new OBDModuleInformation(0);
-        obdInfo.setSupportedSpns(List.of(SupportedSPN.create(123, true, true, true, 1)));
+        obdInfo.setDm24(DM24SPNSupportPacket.create(0, SupportedSPN.create(123, true, true, true, 1)));
         dataRepository.putObdModule(obdInfo);
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
         verify(diagnosticMessageModule).requestDM25(any(), eq(0x00));
 
         verify(mockListener, atLeastOnce()).addOutcome(PART_NUMBER,
@@ -165,14 +171,12 @@ public class Part01Step24ControllerTest extends AbstractControllerTest {
     public void testNoResponses() {
 
         OBDModuleInformation obdInfo = new OBDModuleInformation(0);
-        obdInfo.setSupportedSpns(List.of(SupportedSPN.create(123, true, true, true, 1)));
+        obdInfo.setDm24(DM24SPNSupportPacket.create(0, SupportedSPN.create(123, true, true, true, 1)));
         dataRepository.putObdModule(obdInfo);
 
         when(diagnosticMessageModule.requestDM25(any(), eq(0x00))).thenReturn(new BusResult<>(true));
 
         runTest();
-
-        verify(diagnosticMessageModule).setJ1939(j1939);
 
         verify(diagnosticMessageModule).requestDM25(any(), eq(0x00));
 
@@ -198,12 +202,11 @@ public class Part01Step24ControllerTest extends AbstractControllerTest {
         when(diagnosticMessageModule.requestDM25(any(), eq(0x00))).thenReturn(new BusResult<>(false, packet));
 
         OBDModuleInformation obdInfo = new OBDModuleInformation(0);
-        obdInfo.setSupportedSpns(List.of(SupportedSPN.create(123, true, true, true, 1)));
+        obdInfo.setDm24(DM24SPNSupportPacket.create(0, SupportedSPN.create(123, true, true, true, 1)));
         dataRepository.putObdModule(obdInfo);
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
         verify(diagnosticMessageModule).requestDM25(any(), eq(0x00));
 
         assertEquals("", listener.getResults());

--- a/src-test/org/etools/j1939_84/controllers/part02/Part02Step03ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part02/Part02Step03ControllerTest.java
@@ -16,7 +16,6 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executor;
-
 import org.etools.j1939_84.bus.j1939.BusResult;
 import org.etools.j1939_84.bus.j1939.J1939;
 import org.etools.j1939_84.bus.j1939.packets.DM24SPNSupportPacket;
@@ -28,8 +27,8 @@ import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 import org.etools.j1939_84.utils.AbstractControllerTest;
@@ -54,15 +53,6 @@ public class Part02Step03ControllerTest extends AbstractControllerTest {
     private static final int PART_NUMBER = 2;
 
     private static final int STEP_NUMBER = 3;
-
-    private static int[] convertToIntArray(byte[] input) {
-        int[] intArray = new int[input.length];
-        for (int i = 0; i < input.length; i++) {
-            // Range 0 to 255, not -128 to 127
-            intArray[i] = Byte.toUnsignedInt(input[i]);
-        }
-        return intArray;
-    }
 
     @Mock
     private BannerModule bannerModule;
@@ -110,17 +100,24 @@ public class Part02Step03ControllerTest extends AbstractControllerTest {
                 dataRepository,
                 DateTimeModule.getInstance());
 
-        setup(instance, listener, j1939, engineSpeedModule, reportFileModule, executor, vehicleInformationModule);
+        setup(instance,
+              listener,
+              j1939,
+              executor,
+              reportFileModule,
+              engineSpeedModule,
+              vehicleInformationModule,
+              diagnosticMessageModule);
     }
 
     @After
     public void tearDown() throws Exception {
         verifyNoMoreInteractions(executor,
-                engineSpeedModule,
-                bannerModule,
-                vehicleInformationModule,
+                                 engineSpeedModule,
+                                 bannerModule,
+                                 vehicleInformationModule,
                                  diagnosticMessageModule,
-                mockListener);
+                                 mockListener);
     }
 
     @Test
@@ -187,13 +184,13 @@ public class Part02Step03ControllerTest extends AbstractControllerTest {
         assertEquals(expected, listener.getResults());
 
         verify(mockListener).addOutcome(PART_NUMBER,
-                STEP_NUMBER,
-                FAIL,
-                "6.2.3.2.a - Message data received from Engine #1 (0) differs from that provided in part 6.1.4");
+                                        STEP_NUMBER,
+                                        FAIL,
+                                        "6.2.3.2.a - Message data received from Engine #1 (0) differs from that provided in part 6.1.4");
         verify(mockListener).addOutcome(PART_NUMBER,
-                STEP_NUMBER,
-                FAIL,
-                "6.2.3.2.a - Message data received from Engine #2 (1) differs from that provided in part 6.1.4");
+                                        STEP_NUMBER,
+                                        FAIL,
+                                        "6.2.3.2.a - Message data received from Engine #2 (1) differs from that provided in part 6.1.4");
     }
 
     @Test
@@ -218,7 +215,7 @@ public class Part02Step03ControllerTest extends AbstractControllerTest {
 
     @Test
     @TestDoc(value = @TestItem(verifies = "6.2.3.2.b"),
-             description = "Verify that step completes without errors when none of the fail criteria are met.")
+            description = "Verify that step completes without errors when none of the fail criteria are met.")
     public void testNoFailures() {
 
         {

--- a/src-test/org/etools/j1939_84/controllers/part02/Part02Step10ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part02/Part02Step10ControllerTest.java
@@ -15,8 +15,8 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.concurrent.Executor;
-
 import org.etools.j1939_84.bus.j1939.J1939;
+import org.etools.j1939_84.bus.j1939.packets.DM24SPNSupportPacket;
 import org.etools.j1939_84.bus.j1939.packets.DM30ScaledTestResultsPacket;
 import org.etools.j1939_84.bus.j1939.packets.ScaledTestResult;
 import org.etools.j1939_84.bus.j1939.packets.SupportedSPN;
@@ -27,8 +27,8 @@ import org.etools.j1939_84.controllers.part01.Part01Step12Controller;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
-import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.DiagnosticMessageModule;
+import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 import org.etools.j1939_84.utils.AbstractControllerTest;
@@ -86,23 +86,30 @@ public class Part02Step10ControllerTest extends AbstractControllerTest {
         DateTimeModule.setInstance(null);
 
         instance = new Part02Step10Controller(executor,
-                engineSpeedModule,
-                bannerModule,
-                dataRepository,
-                vehicleInformationModule,
+                                              engineSpeedModule,
+                                              bannerModule,
+                                              dataRepository,
+                                              vehicleInformationModule,
                                               diagnosticMessageModule,
-                DateTimeModule.getInstance());
+                                              DateTimeModule.getInstance());
 
-        setup(instance, listener, j1939, engineSpeedModule, reportFileModule, executor, vehicleInformationModule);
+        setup(instance,
+              listener,
+              j1939,
+              executor,
+              reportFileModule,
+              engineSpeedModule,
+              vehicleInformationModule,
+              diagnosticMessageModule);
     }
 
     @After
     public void tearDown() {
         verifyNoMoreInteractions(executor,
-                engineSpeedModule,
-                bannerModule,
-                vehicleInformationModule,
-                mockListener);
+                                 engineSpeedModule,
+                                 bannerModule,
+                                 vehicleInformationModule,
+                                 mockListener);
     }
 
     @Test
@@ -124,12 +131,10 @@ public class Part02Step10ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-
         verify(mockListener).addOutcome(PART,
-                STEP,
-                FAIL,
-                "6.2.10.2.a - Engine #1 (0) provided different test result labels from the test results received in part 1 test 12");
+                                        STEP,
+                                        FAIL,
+                                        "6.2.10.2.a - Engine #1 (0) provided different test result labels from the test results received in part 1 test 12");
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getMilestones());
@@ -155,16 +160,14 @@ public class Part02Step10ControllerTest extends AbstractControllerTest {
 
         when(diagnosticMessageModule.getDM30Packets(any(), eq(0), eq(spn1)))
                 .thenReturn(List.of(DM30ScaledTestResultsPacket.create(0, testResult1),
-                        DM30ScaledTestResultsPacket.create(0, testResult2)));
+                                    DM30ScaledTestResultsPacket.create(0, testResult2)));
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-
         verify(mockListener).addOutcome(PART,
-                STEP,
-                FAIL,
-                "6.2.10.2.a - Engine #1 (0) provided different test result labels from the test results received in part 1 test 12");
+                                        STEP,
+                                        FAIL,
+                                        "6.2.10.2.a - Engine #1 (0) provided different test result labels from the test results received in part 1 test 12");
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getMilestones());
@@ -200,8 +203,7 @@ public class Part02Step10ControllerTest extends AbstractControllerTest {
 
         SupportedSPN spn1 = SupportedSPN.create(5319, true, false, false, 1);
         SupportedSPN spn2 = SupportedSPN.create(987, true, false, false, 1);
-        obdModule0.setSupportedSpns(List.of(spn1, spn2));
-
+        obdModule0.setDm24(DM24SPNSupportPacket.create(0, spn1, spn2));
         dataRepository.putObdModule(obdModule0);
 
         OBDModuleInformation obdModule3 = new OBDModuleInformation(3);
@@ -213,8 +215,6 @@ public class Part02Step10ControllerTest extends AbstractControllerTest {
                 .thenReturn(List.of(DM30ScaledTestResultsPacket.create(0, testResult2)));
 
         runTest();
-
-        verify(diagnosticMessageModule).setJ1939(j1939);
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getMilestones());
@@ -244,8 +244,7 @@ public class Part02Step10ControllerTest extends AbstractControllerTest {
 
         SupportedSPN spn1 = SupportedSPN.create(5319, true, false, false, 1);
         SupportedSPN spn2 = SupportedSPN.create(987, true, false, false, 1);
-        obdModule0.setSupportedSpns(List.of(spn1, spn2));
-
+        obdModule0.setDm24(DM24SPNSupportPacket.create(0, spn1, spn2));
         dataRepository.putObdModule(obdModule0);
 
         when(diagnosticMessageModule.getDM30Packets(any(), eq(0), eq(spn1)))
@@ -255,17 +254,15 @@ public class Part02Step10ControllerTest extends AbstractControllerTest {
 
         runTest();
 
-        verify(diagnosticMessageModule).setJ1939(j1939);
-
         verify(mockListener).addOutcome(PART,
-                STEP,
-                WARN,
-                "6.2.10.3.a - All test results from Engine #1 (0) are still initialized");
+                                        STEP,
+                                        WARN,
+                                        "6.2.10.3.a - All test results from Engine #1 (0) are still initialized");
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getMilestones());
         assertEquals("WARN: 6.2.10.3.a - All test results from Engine #1 (0) are still initialized" + NL,
-                listener.getResults());
+                     listener.getResults());
     }
 
 }

--- a/src-test/org/etools/j1939_84/controllers/part02/Part02Step14ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part02/Part02Step14ControllerTest.java
@@ -13,11 +13,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import java.util.List;
 import java.util.concurrent.Executor;
 import org.etools.j1939_84.bus.Packet;
 import org.etools.j1939_84.bus.j1939.BusResult;
 import org.etools.j1939_84.bus.j1939.J1939;
+import org.etools.j1939_84.bus.j1939.packets.DM24SPNSupportPacket;
 import org.etools.j1939_84.bus.j1939.packets.DM25ExpandedFreezeFrame;
 import org.etools.j1939_84.bus.j1939.packets.SupportedSPN;
 import org.etools.j1939_84.controllers.DataRepository;
@@ -25,8 +25,8 @@ import org.etools.j1939_84.controllers.ResultsListener;
 import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
 import org.etools.j1939_84.modules.DateTimeModule;
+import org.etools.j1939_84.modules.DiagnosticMessageModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
@@ -88,7 +88,14 @@ public class Part02Step14ControllerTest extends AbstractControllerTest {
                                               DateTimeModule.getInstance(),
                                               diagnosticMessageModule);
 
-        setup(instance, listener, j1939, engineSpeedModule, reportFileModule, executor, vehicleInformationModule);
+        setup(instance,
+              listener,
+              j1939,
+              executor,
+              reportFileModule,
+              engineSpeedModule,
+              vehicleInformationModule,
+              diagnosticMessageModule);
     }
 
     @After
@@ -137,7 +144,7 @@ public class Part02Step14ControllerTest extends AbstractControllerTest {
         when(diagnosticMessageModule.requestDM25(any(), eq(0x00))).thenReturn(new BusResult<>(false, packet));
 
         OBDModuleInformation obdInfo = new OBDModuleInformation(0);
-        obdInfo.setSupportedSpns(List.of(SupportedSPN.create(123, true, true, true, 1)));
+        obdInfo.setDm24(DM24SPNSupportPacket.create(0, SupportedSPN.create(123, true, true, true, 1)));
         dataRepository.putObdModule(obdInfo);
 
         runTest();
@@ -160,7 +167,7 @@ public class Part02Step14ControllerTest extends AbstractControllerTest {
     public void testNoResponses() {
 
         OBDModuleInformation obdInfo = new OBDModuleInformation(0);
-        obdInfo.setSupportedSpns(List.of(SupportedSPN.create(123, true, true, true, 1)));
+        obdInfo.setDm24(DM24SPNSupportPacket.create(0, SupportedSPN.create(123, true, true, true, 1)));
         dataRepository.putObdModule(obdInfo);
 
         when(diagnosticMessageModule.requestDM25(any(), eq(0x00))).thenReturn(new BusResult<>(true));
@@ -193,7 +200,7 @@ public class Part02Step14ControllerTest extends AbstractControllerTest {
         when(diagnosticMessageModule.requestDM25(any(), eq(0x00))).thenReturn(new BusResult<>(false, packet));
 
         OBDModuleInformation obdInfo = new OBDModuleInformation(0);
-        obdInfo.setSupportedSpns(List.of(SupportedSPN.create(123, true, true, true, 1)));
+        obdInfo.setDm24(DM24SPNSupportPacket.create(0, SupportedSPN.create(123, true, true, true, 1)));
         dataRepository.putObdModule(obdInfo);
 
         runTest();

--- a/src-test/org/etools/j1939_84/controllers/part03/Part03Step12ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part03/Part03Step12ControllerTest.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import java.util.List;
 import java.util.concurrent.Executor;
 import org.etools.j1939_84.bus.j1939.BusResult;
 import org.etools.j1939_84.bus.j1939.J1939;
@@ -136,7 +135,7 @@ public class Part03Step12ControllerTest extends AbstractControllerTest {
         var spn = SupportedSPN.create(123, false, false, false, 0);
 
         OBDModuleInformation moduleInfo = new OBDModuleInformation(0);
-        moduleInfo.setSupportedSpns(List.of(spn));
+        moduleInfo.setDm24(DM24SPNSupportPacket.create(0, spn));
         dataRepository.putObdModule(moduleInfo);
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
@@ -162,7 +161,7 @@ public class Part03Step12ControllerTest extends AbstractControllerTest {
         var spn2 = SupportedSPN.create(123, true, true, true, 1);
 
         OBDModuleInformation moduleInfo = new OBDModuleInformation(0);
-        moduleInfo.setSupportedSpns(List.of(spn1));
+        moduleInfo.setDm24(DM24SPNSupportPacket.create(0, spn1));
         dataRepository.putObdModule(moduleInfo);
 
         var dm24 = DM24SPNSupportPacket.create(0, spn2);
@@ -183,7 +182,7 @@ public class Part03Step12ControllerTest extends AbstractControllerTest {
         var spn2 = SupportedSPN.create(456, false, false, false, 0);
 
         OBDModuleInformation moduleInfo = new OBDModuleInformation(0);
-        moduleInfo.setSupportedSpns(List.of(spn1));
+        moduleInfo.setDm24(DM24SPNSupportPacket.create(0, spn1));
         dataRepository.putObdModule(moduleInfo);
 
         var dm24 = DM24SPNSupportPacket.create(0, spn2);

--- a/src-test/org/etools/j1939_84/controllers/part03/Part03Step13ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part03/Part03Step13ControllerTest.java
@@ -3,15 +3,35 @@
  */
 package org.etools.j1939_84.controllers.part03;
 
+import static org.etools.j1939_84.J1939_84.NL;
+import static org.etools.j1939_84.model.Outcome.FAIL;
+import static org.etools.j1939_84.model.Outcome.WARN;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.concurrent.Executor;
+import org.etools.j1939_84.bus.Packet;
+import org.etools.j1939_84.bus.j1939.BusResult;
 import org.etools.j1939_84.bus.j1939.J1939;
+import org.etools.j1939_84.bus.j1939.packets.DM24SPNSupportPacket;
+import org.etools.j1939_84.bus.j1939.packets.DM25ExpandedFreezeFrame;
+import org.etools.j1939_84.bus.j1939.packets.DiagnosticTroubleCode;
+import org.etools.j1939_84.bus.j1939.packets.FreezeFrame;
+import org.etools.j1939_84.bus.j1939.packets.SupportedSPN;
+import org.etools.j1939_84.bus.j1939.packets.model.Spn;
 import org.etools.j1939_84.controllers.DataRepository;
+import org.etools.j1939_84.controllers.FreezeFrameDataTranslator;
 import org.etools.j1939_84.controllers.ResultsListener;
 import org.etools.j1939_84.controllers.StepController;
+import org.etools.j1939_84.controllers.TableA2ValueValidator;
 import org.etools.j1939_84.controllers.TestResultsListener;
+import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
 import org.etools.j1939_84.modules.DiagnosticMessageModule;
@@ -60,6 +80,9 @@ public class Part03Step13ControllerTest extends AbstractControllerTest {
 
     private DataRepository dataRepository;
 
+    @Mock
+    private TableA2ValueValidator validator;
+
     private StepController instance;
 
     @Before
@@ -69,13 +92,16 @@ public class Part03Step13ControllerTest extends AbstractControllerTest {
         dataRepository = DataRepository.newInstance();
 
         listener = new TestResultsListener(mockListener);
+        FreezeFrameDataTranslator translator = new FreezeFrameDataTranslator();
         instance = new Part03Step13Controller(executor,
                                               bannerModule,
                                               dateTimeModule,
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
-                                              diagnosticMessageModule);
+                                              diagnosticMessageModule,
+                                              translator,
+                                              validator);
 
         setup(instance,
               listener,
@@ -95,7 +121,9 @@ public class Part03Step13ControllerTest extends AbstractControllerTest {
                                  engineSpeedModule,
                                  bannerModule,
                                  vehicleInformationModule,
-                                 mockListener);
+                                 diagnosticMessageModule,
+                                 mockListener,
+                                 validator);
     }
 
     @Test
@@ -119,7 +147,343 @@ public class Part03Step13ControllerTest extends AbstractControllerTest {
     }
 
     @Test
-    public void testRun() {
+    public void testHappyPath() {
+        OBDModuleInformation moduleInfo = new OBDModuleInformation(0);
+        DiagnosticTroubleCode dtc = DiagnosticTroubleCode.create(102, 4, 0, 1);
+        moduleInfo.setEmissionDTCs(List.of(dtc));
+        moduleInfo.setDm24(createDM24());
+        dataRepository.putObdModule(moduleInfo);
 
+        when(diagnosticMessageModule.requestDM25(any(), eq(0))).thenReturn(new BusResult<>(false, createDM25()));
+
+        runTest();
+
+        verify(diagnosticMessageModule).requestDM25(any(), eq(0));
+        verify(validator).reportWarnings(any(), any(), eq("6.3.13.2.e"));
+
+        String expected = "";
+        expected += "6.3.13.1.c - Received from Engine #1 (0): " + NL;
+        expected += "Freeze Frame: {" + NL;
+        expected += "DTC 102:4 - Engine Intake Manifold #1 Pressure, Voltage Below Normal, Or Shorted To Low Source - 1 times" + NL;
+        expected += "SPN Data: 19 F8 4D 84 82 02 31 A7 C6 24 CB 00 0A 20 4E B3 3B E0 01 04 73 A2 04 7D A5 09 15 01 62 A9 25 7C 29 54 14 B6 2D A0 64 0F 3C 00 00 56 00 FF FF A0 0F 01 00 04 00 D6 2C 02 00 40 2E 1F 1A 00 C6 02 00 00 C0 AF 80 25 96 25 73 2B B9 2D 76 09 0B 00 86 29 AF 30 00 00 00 D7 52 09 58 34 C0 2B 20 1C 3A 41 D3 E1 DF 8C C1 E5 61 00 00 00 9E 15 01 FF FF FF FF FF FF 1F 50 14" + NL;
+        expected += "SPN    91, Accelerator Pedal Position 1: 10.000000 %" + NL;
+        expected += "SPN    27, Engine EGR 1 Valve Position: 49.900000 %" + NL;
+        expected += "SPN   513, Actual Engine - Percent Torque: 7.000000 %" + NL;
+        expected += "SPN   132, Engine Intake Air Mass Flow Rate: 32.100000 kg/h" + NL;
+        expected += "SPN  3217, Engine Exhaust 1 Percent Oxygen 1: 9.999714 %" + NL;
+        expected += "SPN   171, Ambient Air Temperature: 21.187500 °C" + NL;
+        expected += "SPN   108, Barometric Pressure: 101.500000 kPa" + NL;
+        expected += "SPN   102, Engine Intake Manifold #1 Pressure: 0.000000 kPa" + NL;
+        expected += "SPN    92, Engine Percent Load At Current Speed: 10.000000 %" + NL;
+        expected += "SPN  2791, Engine EGR 1 Valve 1 Control 1: 50.000000 %" + NL;
+        expected += "SPN  5313, Commanded Engine Fuel Rail Pressure: 59.699219 MPa" + NL;
+        expected += "SPN  5833, Engine Fuel Mass Flow Rate: 2.400000 g/s" + NL;
+        expected += "SPN  5837, Fuel Type: 00000100" + NL;
+        expected += "SPN   641, Engine Variable Geometry Turbocharger Actuator #1: 46.000000 %" + NL;
+        expected += "SPN  1692, Engine Intake Manifold Desired Absolute Pressure: 118.600000 kPa" + NL;
+        expected += "SPN   512, Driver's Demand Engine - Percent Torque: 0.000000 %" + NL;
+        expected += "SPN  2659, Engine EGR 1 Mass Flow Rate: 123.450000 kg/h" + NL;
+        expected += "SPN   168, Battery Potential / Power Input 1: 13.850000 V" + NL;
+        expected += "SPN   110, Engine Coolant Temperature: 58.000000 °C" + NL;
+        expected += "SPN  2630, Engine Charge Air Cooler 1 Outlet Temperature: 28.281250 °C" + NL;
+        expected += "SPN   175, Engine Oil Temperature 1: 58.875000 °C" + NL;
+        expected += "SPN   190, Engine Speed: 650.500000 rpm" + NL;
+        expected += "SPN   173, Engine Exhaust Temperature: 92.687500 °C" + NL;
+        expected += "SPN  1436, Engine Actual Ignition Timing: 1.250000 deg" + NL;
+        expected += "SPN   157, Engine Fuel 1 Injector Metering Rail 1 Pressure: 60.058594 MPa" + NL;
+        expected += "SPN  1440, Engine Fuel Flow Rate 1: 0.000000 m³/h" + NL;
+        expected += "SPN   105, Engine Intake Manifold 1 Temperature: 46.000000 °C" + NL;
+        expected += "SPN  3563, Engine Intake Manifold #1 Absolute Pressure: 0.000000 kPa" + NL;
+        expected += "SPN  3226, AFT 1 Outlet NOx 1: Not Available" + NL;
+        expected += "SPN  3216, Engine Exhaust 1 NOx 1: 0.000000 ppm" + NL;
+        expected += "SPN  3251, AFT 1 DPF Differential Pressure: 0.100000 kPa" + NL;
+        expected += "SPN  3609, AFT 1 DPF Intake Pressure: 0.400000 kPa" + NL;
+        expected += "SPN  4766, AFT 1 Diesel Oxidation Catalyst Outlet Temperature: 85.687500 °C" + NL;
+        expected += "SPN  3610, AFT 1 DPF Outlet Pressure: 0.200000 kPa" + NL;
+        expected += "SPN  3246, AFT 1 DPF Outlet Temperature: 97.000000 °C" + NL;
+        expected += "SPN   976, PTO Governor State: 11111" + NL;
+        expected += "SPN  3301, Time Since Engine Start: 26.000000" + NL;
+        expected += "SPN   247, Engine Total Hours of Operation: 35.500000 h" + NL;
+        expected += "SPN  1176, Engine Turbocharger 1 Compressor Intake Pressure: 101.500000 kPa" + NL;
+        expected += "SPN  1172, Engine Turbocharger 1 Compressor Intake Temperature: 27.000000 °C" + NL;
+        expected += "SPN  2629, Engine Turbocharger 1 Compressor Outlet Temperature: 27.687500 °C" + NL;
+        expected += "SPN  1180, Engine Turbocharger 1 Turbine Intake Temperature: 74.593750 °C" + NL;
+        expected += "SPN  1184, Engine Turbocharger 1 Turbine Outlet Temperature: 92.781250 °C" + NL;
+        expected += "SPN   103, Engine Turbocharger 1 Speed: 9688.000000 rpm" + NL;
+        expected += "SPN  2795, Engine Variable Geometry Turbocharger (VGT) 1 Actuator Position: 4.400000 %" + NL;
+        expected += "SPN  3490, AFT 1 Purge Air Actuator: 00" + NL;
+        expected += "SPN   412, Engine EGR 1 Temperature: 59.187500 °C" + NL;
+        expected += "SPN    94, Engine Fuel Delivery Pressure: 700.000000 kPa" + NL;
+        expected += "SPN   183, Engine Fuel Rate: 2.400000 l/h" + NL;
+        expected += "SPN  1081, Engine Wait to Start Lamp: 00" + NL;
+        expected += "SPN  3700, AFT DPF Active Regeneration Status: 00" + NL;
+        expected += "SPN  1761, AFT 1 DEF Tank Volume: 86.000000 %" + NL;
+        expected += "SPN   544, Engine Reference Torque: 2386.000000 Nm" + NL;
+        expected += "SPN   531, Engine Speed At Point 5: 1675.000000 rpm" + NL;
+        expected += "SPN   530, Engine Speed At Point 4: 1400.000000 rpm" + NL;
+        expected += "SPN   529, Engine Speed At Point 3: 900.000000 rpm" + NL;
+        expected += "SPN   528, Engine Speed At Point 2: 2087.250000 rpm" + NL;
+        expected += "SPN   543, Engine Percent Torque At Point 5: 86.000000 %" + NL;
+        expected += "SPN   542, Engine Percent Torque At Point 4: 100.000000 %" + NL;
+        expected += "SPN   541, Engine Percent Torque At Point 3: 98.000000 %" + NL;
+        expected += "SPN   540, Engine Percent Torque At Point 2: 15.000000 %" + NL;
+        expected += "SPN   539, Engine Percent Torque At Idle, Point 1: 68.000000 %" + NL;
+        expected += "SPN  5466, AFT 1 DPF Soot Load Regeneration Threshold: 62.652500 %" + NL;
+        expected += "SPN    84, Wheel-Based Vehicle Speed: 0.000000 km/h" + NL;
+        expected += "SPN  5457, Engine Variable Geometry Turbocharger 1 Control Mode: 00" + NL;
+        expected += "SPN    96, Fuel Level 1: 63.200000 %" + NL;
+        expected += "SPN   158, Key Switch Battery Potential: 13.850000 V" + NL;
+        expected += "SPN  3523, AFT 1 Total Regeneration Time: Not Available" + NL;
+        expected += "SPN  7351, AFT 1 Outlet Corrected NOx: Not Available" + NL;
+        expected += "SPN   106, Engine Intake Air Pressure: 62.000000 kPa" + NL;
+        expected += "SPN   188, Engine Speed At Idle, Point 1: 650.000000 rpm" + NL;
+        expected += "}" + NL;
+        expected += NL;
+        assertEquals(expected, listener.getResults());
+    }
+
+    @Test
+    public void testResponseWithRetry() {
+        OBDModuleInformation moduleInfo = new OBDModuleInformation(0);
+        DM24SPNSupportPacket dm24 = DM24SPNSupportPacket.create(0, SupportedSPN.create(91, true, true, true, 1));
+        DiagnosticTroubleCode dtc = DiagnosticTroubleCode.create(102, 4, 0, 1);
+        moduleInfo.setEmissionDTCs(List.of(dtc));
+        moduleInfo.setDm24(dm24);
+        dataRepository.putObdModule(moduleInfo);
+
+        DM25ExpandedFreezeFrame dm25 = DM25ExpandedFreezeFrame.create(0, new FreezeFrame(dtc, Spn.create(91, 10)));
+        when(diagnosticMessageModule.requestDM25(any(), eq(0)))
+                .thenReturn(new BusResult<>(true))
+                .thenReturn(new BusResult<>(false, dm25));
+
+        runTest();
+
+        verify(diagnosticMessageModule, times(2)).requestDM25(any(), eq(0));
+        verify(validator).reportWarnings(any(), any(), eq("6.3.13.2.e"));
+
+        String expected = "";
+        expected += "FAIL: 6.3.13.2.a - Retry was required to obtain DM25 response from Engine #1 (0)" + NL;
+        expected += "6.3.13.1.c - Received from Engine #1 (0): " + NL;
+        expected += "Freeze Frame: {" + NL;
+        expected += "DTC 102:4 - Engine Intake Manifold #1 Pressure, Voltage Below Normal, Or Shorted To Low Source - 1 times" + NL;
+        expected += "SPN Data: 19" + NL;
+        expected += "SPN    91, Accelerator Pedal Position 1: 10.000000 %" + NL;
+        expected += "}" + NL;
+        expected += NL;
+        assertEquals(expected, listener.getResults());
+
+        verify(mockListener).addOutcome(PART_NUMBER,
+                                        STEP_NUMBER,
+                                        FAIL,
+                                        "6.3.13.2.a - Retry was required to obtain DM25 response from Engine #1 (0)");
+    }
+
+    @Test
+    public void testFailureForDifferentDTC() {
+        OBDModuleInformation moduleInfo = new OBDModuleInformation(0);
+        DiagnosticTroubleCode dtc1 = DiagnosticTroubleCode.create(555, 4, 0, 1);
+        moduleInfo.setEmissionDTCs(List.of(dtc1));
+        DM24SPNSupportPacket dm24 = DM24SPNSupportPacket.create(0, SupportedSPN.create(91, true, true, true, 1));
+        moduleInfo.setDm24(dm24);
+        dataRepository.putObdModule(moduleInfo);
+
+        DiagnosticTroubleCode dtc = DiagnosticTroubleCode.create(102, 4, 0, 1);
+        DM25ExpandedFreezeFrame dm25 = DM25ExpandedFreezeFrame.create(0, new FreezeFrame(dtc, Spn.create(91, 10)));
+        when(diagnosticMessageModule.requestDM25(any(), eq(0))).thenReturn(new BusResult<>(false, dm25));
+
+        runTest();
+
+        verify(diagnosticMessageModule).requestDM25(any(), eq(0));
+        verify(validator).reportWarnings(any(), any(), eq("6.3.13.2.e"));
+
+        String expected = "";
+        expected += "6.3.13.1.c - Received from Engine #1 (0): " + NL;
+        expected += "Freeze Frame: {" + NL;
+        expected += "DTC 102:4 - Engine Intake Manifold #1 Pressure, Voltage Below Normal, Or Shorted To Low Source - 1 times" + NL;
+        expected += "SPN Data: 19" + NL;
+        expected += "SPN    91, Accelerator Pedal Position 1: 10.000000 %" + NL;
+        expected += "}" + NL;
+        expected += NL;
+        expected += "FAIL: 6.3.13.2.d - Freeze frame data from Engine #1 (0) does not include the same SPN+FMI as DM6 Pending DTC earlier in this part." + NL;
+        assertEquals(expected, listener.getResults());
+
+        verify(mockListener).addOutcome(PART_NUMBER,
+                                        STEP_NUMBER,
+                                        FAIL,
+                                        "6.3.13.2.d - Freeze frame data from Engine #1 (0) does not include the same SPN+FMI as DM6 Pending DTC earlier in this part.");
+    }
+
+    @Test
+    public void testFailureMultipleFreezeFrames() {
+        OBDModuleInformation moduleInfo = new OBDModuleInformation(0);
+        DiagnosticTroubleCode dtc1 = DiagnosticTroubleCode.create(102, 4, 0, 1);
+        moduleInfo.setEmissionDTCs(List.of(dtc1));
+        DM24SPNSupportPacket dm24 = DM24SPNSupportPacket.create(0, SupportedSPN.create(91, true, true, true, 1));
+        moduleInfo.setDm24(dm24);
+        dataRepository.putObdModule(moduleInfo);
+
+        DiagnosticTroubleCode dtc2 = DiagnosticTroubleCode.create(999, 4, 0, 2);
+        DM25ExpandedFreezeFrame dm25 = DM25ExpandedFreezeFrame.create(0,
+                                                                      new FreezeFrame(dtc1, Spn.create(91, 10)),
+                                                                      new FreezeFrame(dtc2, Spn.create(91, 100)));
+        when(diagnosticMessageModule.requestDM25(any(), eq(0))).thenReturn(new BusResult<>(false, dm25));
+
+        runTest();
+
+        verify(diagnosticMessageModule).requestDM25(any(), eq(0));
+        verify(validator, times(2)).reportWarnings(any(), any(), eq("6.3.13.2.e"));
+
+        String expected = "";
+        expected += "6.3.13.1.c - Received from Engine #1 (0): " + NL;
+        expected += "Freeze Frame: {" + NL;
+        expected += "DTC 102:4 - Engine Intake Manifold #1 Pressure, Voltage Below Normal, Or Shorted To Low Source - 1 times" + NL;
+        expected += "SPN Data: 19" + NL;
+        expected += "SPN    91, Accelerator Pedal Position 1: 10.000000 %" + NL;
+        expected += "}" + NL;
+        expected += NL;
+        expected += "6.3.13.1.c - Received from Engine #1 (0): " + NL;
+        expected += "Freeze Frame: {" + NL;
+        expected += "DTC 999:4 - Trip Gear Down Distance, Voltage Below Normal, Or Shorted To Low Source - 2 times" + NL;
+        expected += "SPN Data: FA" + NL;
+        expected += "SPN    91, Accelerator Pedal Position 1: 100.000000 %" + NL;
+        expected += "}" + NL;
+        expected += "" + NL;
+        expected += "WARN: 6.3.13.2.e - More than 1 freeze frame data set is included in the response from Engine #1 (0)" + NL;
+        assertEquals(expected, listener.getResults());
+
+        verify(mockListener).addOutcome(PART_NUMBER,
+                                        STEP_NUMBER,
+                                        WARN,
+                                        "6.3.13.2.e - More than 1 freeze frame data set is included in the response from Engine #1 (0)");
+    }
+
+    @Test
+    public void testFailureMismatchedDataLengths() {
+        OBDModuleInformation moduleInfo = new OBDModuleInformation(0);
+        DiagnosticTroubleCode dtc = DiagnosticTroubleCode.create(102, 4, 0, 1);
+        moduleInfo.setEmissionDTCs(List.of(dtc));
+        DM24SPNSupportPacket dm24 = DM24SPNSupportPacket.create(0,
+                                                                SupportedSPN.create(91, true, true, true, 1),
+                                                                SupportedSPN.create(92, true, true, true, 1));
+        moduleInfo.setDm24(dm24);
+        dataRepository.putObdModule(moduleInfo);
+
+        DM25ExpandedFreezeFrame dm25 = DM25ExpandedFreezeFrame.create(0, new FreezeFrame(dtc, Spn.create(91, 10)));
+        when(diagnosticMessageModule.requestDM25(any(), eq(0))).thenReturn(new BusResult<>(false, dm25));
+
+        runTest();
+
+        verify(diagnosticMessageModule).requestDM25(any(), eq(0));
+        verify(validator).reportWarnings(any(), any(), eq("6.3.13.2.e"));
+
+        String expected = "";
+        expected += "6.3.13.1.c - Received from Engine #1 (0): " + NL;
+        expected += "Freeze Frame: {" + NL;
+        expected += "DTC 102:4 - Engine Intake Manifold #1 Pressure, Voltage Below Normal, Or Shorted To Low Source - 1 times" + NL;
+        expected += "SPN Data: 19" + NL;
+        expected += "}" + NL;
+        expected += NL;
+        expected += "FAIL: 6.3.13.2.c - Received data (1) does not match expected number of bytes (2) based on DM24 supported SPN list for Engine #1 (0)" + NL;
+        assertEquals(expected, listener.getResults());
+
+        verify(mockListener).addOutcome(PART_NUMBER,
+                                        STEP_NUMBER,
+                                        FAIL,
+                                        "6.3.13.2.c - Received data (1) does not match expected number of bytes (2) based on DM24 supported SPN list for Engine #1 (0)");
+    }
+
+    @Test
+    public void testNoResponses() {
+        OBDModuleInformation moduleInfo = new OBDModuleInformation(0);
+        dataRepository.putObdModule(moduleInfo);
+
+        when(diagnosticMessageModule.requestDM25(any(), eq(0)))
+                .thenReturn(new BusResult<>(true))
+                .thenReturn(new BusResult<>(true));
+
+        runTest();
+
+        verify(diagnosticMessageModule, times(2)).requestDM25(any(), eq(0));
+
+        String expected = "";
+        expected += "FAIL: 6.3.13.2.a - Retry was required to obtain DM25 response from Engine #1 (0)" + NL;
+        expected += "FAIL: 6.3.13.2.b - No ECU has freeze frame data to report" + NL;
+        expected += "FAIL: 6.3.13.2.g - OBD module Engine #1 (0) did not provide a NACK for the DS query" + NL;
+        assertEquals(expected, listener.getResults());
+
+        verify(mockListener).addOutcome(PART_NUMBER,
+                                        STEP_NUMBER,
+                                        FAIL,
+                                        "6.3.13.2.a - Retry was required to obtain DM25 response from Engine #1 (0)");
+
+        verify(mockListener).addOutcome(PART_NUMBER,
+                                        STEP_NUMBER,
+                                        FAIL,
+                                        "6.3.13.2.b - No ECU has freeze frame data to report");
+
+        verify(mockListener).addOutcome(PART_NUMBER,
+                                        STEP_NUMBER,
+                                        FAIL,
+                                        "6.3.13.2.g - OBD module Engine #1 (0) did not provide a NACK for the DS query");
+    }
+
+    private static DM24SPNSupportPacket createDM24() {
+        //@formatter:off
+        int[] data = {
+                0x5B, 0x00, 0x1C, 0x01, 0x1B, 0x00, 0x1C, 0x02, 0x01, 0x02, 0x1C, 0x01, 0x84, 0x00, 0x1C, 0x02, 0x91,
+                0x0C, 0x18, 0x02, 0xAB, 0x00, 0x1C, 0x02, 0x6C, 0x00, 0x1C, 0x01, 0x66, 0x00, 0x18, 0x01, 0x5C, 0x00,
+                0x1C, 0x01, 0xE7, 0x0A, 0x1C, 0x02, 0xC1, 0x14, 0x1C, 0x02, 0xC9, 0x16, 0x1C, 0x02, 0xCD, 0x16, 0x1C,
+                0x01, 0x81, 0x02, 0x1C, 0x01, 0x9C, 0x06, 0x1C, 0x02, 0xC1, 0x0D, 0x1D, 0x00, 0x00, 0x02, 0x1C, 0x01,
+                0x63, 0x0A, 0x1C, 0x02, 0xA8, 0x00, 0x1C, 0x02, 0x6E, 0x00, 0x1C, 0x01, 0x46, 0x0A, 0x18, 0x02, 0xAF,
+                0x00, 0x1C, 0x02, 0xBE, 0x00, 0x1C, 0x02, 0xAD, 0x00, 0x1C, 0x02, 0xB9, 0x04, 0x19, 0x00, 0x9C, 0x05,
+                0x1C, 0x02, 0x9D, 0x00, 0x18, 0x02, 0xA0, 0x05, 0x1C, 0x02, 0x69, 0x00, 0x1C, 0x01, 0xEB, 0x0D, 0x1C,
+                0x01, 0x9A, 0x0C, 0x18, 0x02, 0x90, 0x0C, 0x18, 0x02, 0xB3, 0x0C, 0x1C, 0x02, 0x19, 0x0E, 0x1C, 0x02,
+                0x9E, 0x12, 0x1C, 0x02, 0x1A, 0x0E, 0x1C, 0x02, 0xAE, 0x0C, 0x1C, 0x02, 0xCB, 0x16, 0x1B, 0x00, 0xD0,
+                0x03, 0x1C, 0x01, 0xE5, 0x0C, 0x1C, 0x02, 0xF7, 0x00, 0x1C, 0x04, 0x98, 0x04, 0x1C, 0x02, 0x94, 0x04,
+                0x1C, 0x02, 0x45, 0x0A, 0x1C, 0x02, 0x9C, 0x04, 0x1C, 0x02, 0xA0, 0x04, 0x1C, 0x02, 0x67, 0x00, 0x1C,
+                0x02, 0xEB, 0x0A, 0x1C, 0x01, 0xA2, 0x0D, 0x1C, 0x01, 0x9C, 0x01, 0x1C, 0x02, 0x5E, 0x00, 0x1C, 0x01,
+                0xB7, 0x00, 0x1C, 0x02, 0x39, 0x04, 0x1C, 0x01, 0x74, 0x0E, 0x1C, 0x01, 0xE1, 0x06, 0x1C, 0x01, 0x20,
+                0x02, 0x1C, 0x02, 0x13, 0x02, 0x1C, 0x02, 0x12, 0x02, 0x1C, 0x02, 0x11, 0x02, 0x1C, 0x02, 0x10, 0x02,
+                0x1C, 0x02, 0x1F, 0x02, 0x1C, 0x01, 0x1E, 0x02, 0x1C, 0x01, 0x1D, 0x02, 0x1C, 0x01, 0x1C, 0x02, 0x1C,
+                0x01, 0x1B, 0x02, 0x1C, 0x01, 0x5A, 0x15, 0x1C, 0x02, 0x54, 0x00, 0x1C, 0x02, 0x51, 0x15, 0x1C, 0x01,
+                0xC3, 0x16, 0x1D, 0x00, 0xBD, 0x04, 0x1D, 0x00, 0x9D, 0x12, 0x1D, 0x00, 0x08, 0x11, 0x1D, 0x00, 0x0B,
+                0x11, 0x1D, 0x00, 0xEB, 0x00, 0x1D, 0x00, 0xF8, 0x00, 0x1D, 0x00, 0x57, 0x15, 0x1D, 0x00, 0xE6, 0x16,
+                0x1D, 0x00, 0x3A, 0x10, 0x1D, 0x00, 0xBC, 0x0D, 0x1D, 0x01, 0xA4, 0x0C, 0x1D, 0x00, 0x35, 0x16, 0x1D,
+                0x00, 0x65, 0x06, 0x1D, 0x00, 0xEF, 0x1A, 0x1D, 0x00, 0xC5, 0x16, 0x1D, 0x00, 0xED, 0x1A, 0x1D, 0x00,
+                0x40, 0x06, 0x1D, 0x00, 0x64, 0x06, 0x1D, 0x00, 0x20, 0x10, 0x1D, 0x00, 0x23, 0x10, 0x1D, 0x00, 0xEE,
+                0x1A, 0x1D, 0x00, 0x02, 0x02, 0x1D, 0x00, 0x1F, 0x10, 0x1D, 0x00, 0xE6, 0x0C, 0x1D, 0x00, 0x22, 0x10,
+                0x1D, 0x00, 0x21, 0x10, 0x1D, 0x00, 0x24, 0x10, 0x1D, 0x00, 0xEB, 0x10, 0x1B, 0x00, 0xB2, 0x14, 0x1B,
+                0x00, 0xBC, 0x12, 0x1B, 0x00, 0xC7, 0x14, 0x1B, 0x00, 0xBB, 0x12, 0x1B, 0x00, 0x15, 0x15, 0x1B, 0x00,
+                0xA0, 0x13, 0x1B, 0x00, 0xBA, 0x12, 0x1B, 0x00, 0x0C, 0x11, 0x1B, 0x00, 0x8B, 0x02, 0x1B, 0x00, 0x8C,
+                0x02, 0x1B, 0x00, 0x8D, 0x02, 0x1B, 0x00, 0x8E, 0x02, 0x1B, 0x00, 0x8F, 0x02, 0x1B, 0x00, 0x90, 0x02,
+                0x1B, 0x00, 0x90, 0x12, 0x1B, 0x00, 0x42, 0x15, 0x1B, 0x00, 0xF2, 0x0B, 0x1B, 0x00, 0x2B, 0x05, 0x1B,
+                0x00, 0x2C, 0x05, 0x1B, 0x00, 0x2D, 0x05, 0x1B, 0x00, 0x2E, 0x05, 0x1B, 0x00, 0x2F, 0x05, 0x1B, 0x00,
+                0x30, 0x05, 0x1B, 0x00, 0x67, 0x04, 0x1B, 0x02, 0x9B, 0x0C, 0x1B, 0x00, 0x21, 0x0D, 0x1B, 0x00, 0xA7,
+                0x13, 0x1B, 0x00, 0xA5, 0x1C, 0x1D, 0x00, 0xB9, 0x1C, 0x1D, 0x00, 0xA2, 0x0B, 0x1D, 0x00, 0xBB, 0x0D,
+                0x1D, 0x00, 0x60, 0x00, 0x1C, 0x01, 0x24, 0x0D, 0x1B, 0x00, 0x60, 0x0F, 0x1B, 0x00, 0xC2, 0x14, 0x1B,
+                0x00, 0x75, 0x1A, 0x1B, 0x00, 0x79, 0x1A, 0x1B, 0x00, 0xA1, 0x1C, 0x1B, 0x00, 0x9E, 0x00, 0x1C, 0x02,
+                0xC3, 0x0D, 0x1C, 0x04, 0xB7, 0x1C, 0x1C, 0x02, 0x6A, 0x00, 0x1C, 0x01, 0x87, 0x0E, 0x1D, 0x01, 0xBC,
+                0x00, 0x1C, 0x02, 0xE1, 0x1C, 0x1D, 0x00, 0xD7, 0x0B, 0x1D, 0x01, 0x2A, 0x05, 0x1B, 0x00, 0x9A, 0x1C,
+                0x1B, 0x00, 0x85, 0x05, 0x1B, 0x00, 0x86, 0x05, 0x1B, 0x00, 0x87, 0x05, 0x1B, 0x00, 0x88, 0x05, 0x1B,
+                0x00, 0x89, 0x05, 0x1B, 0x00, 0x8A, 0x05, 0x1B, 0x00
+        };
+        //@formatter:on
+        return new DM24SPNSupportPacket(Packet.create(DM24SPNSupportPacket.PGN, 0, data));
+    }
+
+    private static DM25ExpandedFreezeFrame createDM25() {
+        //@formatter:off
+        int[] data = {
+                0x7C, 0x66, 0x00, 0x04, 0x01, 0x19, 0xF8, 0x4D, 0x84, 0x82, 0x02, 0x31, 0xA7, 0xC6, 0x24, 0xCB, 0x00,
+                0x0A, 0x20, 0x4E, 0xB3, 0x3B, 0xE0, 0x01, 0x04, 0x73, 0xA2, 0x04, 0x7D, 0xA5, 0x09, 0x15, 0x01, 0x62,
+                0xA9, 0x25, 0x7C, 0x29, 0x54, 0x14, 0xB6, 0x2D, 0xA0, 0x64, 0x0F, 0x3C, 0x00, 0x00, 0x56, 0x00, 0xFF,
+                0xFF, 0xA0, 0x0F, 0x01, 0x00, 0x04, 0x00, 0xD6, 0x2C, 0x02, 0x00, 0x40, 0x2E, 0x1F, 0x1A, 0x00, 0xC6,
+                0x02, 0x00, 0x00, 0xC0, 0xAF, 0x80, 0x25, 0x96, 0x25, 0x73, 0x2B, 0xB9, 0x2D, 0x76, 0x09, 0x0B, 0x00,
+                0x86, 0x29, 0xAF, 0x30, 0x00, 0x00, 0x00, 0xD7, 0x52, 0x09, 0x58, 0x34, 0xC0, 0x2B, 0x20, 0x1C, 0x3A,
+                0x41, 0xD3, 0xE1, 0xDF, 0x8C, 0xC1, 0xE5, 0x61, 0x00, 0x00, 0x00, 0x9E, 0x15, 0x01, 0xFF, 0xFF, 0xFF,
+                0xFF, 0xFF, 0xFF, 0x1F, 0x50, 0x14
+        };
+        //@formatter:on
+        return new DM25ExpandedFreezeFrame(Packet.create(DM25ExpandedFreezeFrame.PGN, 0, data));
     }
 }

--- a/src-test/org/etools/j1939_84/modules/DiagnosticMessageModuleTest.java
+++ b/src-test/org/etools/j1939_84/modules/DiagnosticMessageModuleTest.java
@@ -271,11 +271,11 @@ public class DiagnosticMessageModuleTest {
         doReturn(requestPacket).when(j1939).createRequestPacket(pgn, GLOBAL_ADDR);
 
         AcknowledgmentPacket packet1 = new AcknowledgmentPacket(
-                Packet.create(ACK_PGN  | BUS_ADDR, 0x00, 0x01, 0xFF, 0xFF, 0xFF, BUS_ADDR, 0xD3, 0xFE, 0x00));
+                Packet.create(ACK_PGN | BUS_ADDR, 0x00, 0x01, 0xFF, 0xFF, 0xFF, BUS_ADDR, 0xD3, 0xFE, 0x00));
         AcknowledgmentPacket packet2 = new AcknowledgmentPacket(
-                Packet.create(ACK_PGN  | BUS_ADDR, 0x17, 0x00, 0xFF, 0xFF, 0xFF, BUS_ADDR, 0xD3, 0xFE, 0x00));
+                Packet.create(ACK_PGN | BUS_ADDR, 0x17, 0x00, 0xFF, 0xFF, 0xFF, BUS_ADDR, 0xD3, 0xFE, 0x00));
         AcknowledgmentPacket packet3 = new AcknowledgmentPacket(
-                Packet.create(ACK_PGN  | BUS_ADDR, 0x21, 0x00, 0xFF, 0xFF, 0xFF, BUS_ADDR, 0xD3, 0xFE, 0x00));
+                Packet.create(ACK_PGN | BUS_ADDR, 0x21, 0x00, 0xFF, 0xFF, 0xFF, BUS_ADDR, 0xD3, 0xFE, 0x00));
         doReturn(Stream.of(packet1.getPacket(), packet2.getPacket(), packet3.getPacket())).when(j1939).read(anyLong(),
                                                                                                             any());
 
@@ -827,7 +827,7 @@ public class DiagnosticMessageModuleTest {
         doReturn(requestPacket).when(j1939).createRequestPacket(pgn, 0x00);
 
         AcknowledgmentPacket packet1 = new AcknowledgmentPacket(
-                Packet.create(ACK_PGN  | GLOBAL_ADDR, 0x00, 0x01, 0xFF, 0xFF, 0xFF, BUS_ADDR, 0xB7, 0xFD, 0x00));
+                Packet.create(ACK_PGN | GLOBAL_ADDR, 0x00, 0x01, 0xFF, 0xFF, 0xFF, BUS_ADDR, 0xB7, 0xFD, 0x00));
 
         doReturn(Stream.of(packet1.getPacket())).when(j1939).read(anyLong(), any());
 
@@ -898,10 +898,12 @@ public class DiagnosticMessageModuleTest {
                 + NL;
         expected += "DM25 from Engine #1 (0): " + NL;
         expected += "Freeze Frames: [" + NL;
+        expected += "Freeze Frame: {" + NL;
         expected += "DTC 157:7 - Engine Fuel 1 Injector Metering Rail 1 Pressure, Mechanical System Not Responding Or Out Of Adjustment"
                 + NL;
-        expected += "SPN Data: 00 01 7B 00 00 39 3A 5C 0F C4 FB 00 00 00 F1 26 00 00 00 12 7A 7D 80 65 00 00 32 00 00 00 00 84 AD 00 39 2C 30 39 FC 38 C6 35 E0 34 2C 2F 00 00 7D 7D 8A 28 A0 0F A0 0F D1 37 00 CA 28 01 A4 0D 00 A8 C3 B2 C2 C3 00 00 00 00 7E D0 07 00 7D 04 FF"
+        expected += "SPN Data: 00 01 7B 00 00 39 3A 5C 0F C4 FB 00 00 00 F1 26 00 00 00 12 7A 7D 80 65 00 00 32 00 00 00 00 84 AD 00 39 2C 30 39 FC 38 C6 35 E0 34 2C 2F 00 00 7D 7D 8A 28 A0 0F A0 0F D1 37 00 CA 28 01 A4 0D 00 A8 C3 B2 C2 C3 00 00 00 00 7E D0 07 00 7D 04 FF FA"
                 + NL;
+        expected += "}" + NL;
         expected += "]" + NL;
 
         TestResultsListener listener = new TestResultsListener();
@@ -1892,7 +1894,7 @@ public class DiagnosticMessageModuleTest {
         expected += "EI-AECD Number = 3: Timer 1 = errored; Timer 2 = 199468 minutes" + NL;
         expected += "EI-AECD Number = 4: Timer 1 = errored; Timer 2 = n/a" + NL;
         expected += "}" + NL;
-        expected+=NL;
+        expected += NL;
 
         TestResultsListener listener = new TestResultsListener();
         var expectedResult = new RequestResult<>(false, packet1);

--- a/src-test/org/etools/j1939_84/utils/CollectionUtilsTest.java
+++ b/src-test/org/etools/j1939_84/utils/CollectionUtilsTest.java
@@ -4,6 +4,7 @@
 
 package org.etools.j1939_84.utils;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -22,7 +23,7 @@ import org.junit.Test;
  * @author Marianne Schaefer (marianne.m.schaefer@gmail.com)
  */
 public class CollectionUtilsTest {
-@Test
+    @Test
     public void areTwoListsEqualSameType() {
         // verify null objects
         assertTrue(CollectionUtils.areTwoCollectionsEqual(null, null));
@@ -93,7 +94,7 @@ public class CollectionUtilsTest {
         //  Verify inequality of a Collection<> and null
         assertFalse(CollectionUtils.areTwoCollectionsEqual(collectionA, null));
 
-        int[] dataB = new int[]{
+        int[] dataB = new int[] {
                 0xF7, // Test Identifier
                 0x22, // SPN, (bits 8-1) 8 least significant bits of SPN
                 0x0D, // SPN, (bits 8-1) second byte of SPN (most significant at bit 8)
@@ -105,7 +106,7 @@ public class CollectionUtilsTest {
                 0x03, // Test Value
                 0xE8, // Test Limit Maximum
                 0x03, // Test Limit Maximum
-                0x20, // Test Limit Mimimum
+                0x20, // Test Limit Minimum
                 0x03  //Test Limit Minimum
         };
         DM30ScaledTestResultsPacket packetB = new DM30ScaledTestResultsPacket(Packet.create(DM30ScaledTestResultsPacket.PGN,
@@ -131,5 +132,35 @@ public class CollectionUtilsTest {
         List<DM20MonitorPerformanceRatioPacket> listE = new ArrayList<>();
         listE.add(packetA);
         assertTrue(CollectionUtils.areTwoCollectionsEqual(listD, listE));
+    }
+
+    @Test
+    public void testToIntArray() {
+
+        byte[] input = new byte[255];
+        int[] expected = new int[255];
+
+        for (int i = 0; i < 255; i++) {
+            input[i] = (byte) i;
+            expected[i] = i;
+        }
+
+        int[] actual = CollectionUtils.toIntArray(input);
+        assertArrayEquals(expected, actual);
+    }
+
+    @Test
+    public void testToByteArray() {
+
+        byte[] expected = new byte[255];
+        int[] input = new int[255];
+
+        for (int i = 0; i < 255; i++) {
+            input[i] = i;
+            expected[i] = (byte) i;
+        }
+
+        byte[] actual = CollectionUtils.toByteArray(input);
+        assertArrayEquals(expected, actual);
     }
 }

--- a/src/org/etools/j1939_84/bus/j1939/packets/DM24SPNSupportPacket.java
+++ b/src/org/etools/j1939_84/bus/j1939/packets/DM24SPNSupportPacket.java
@@ -34,6 +34,8 @@ public class DM24SPNSupportPacket extends GenericPacket {
 
     private List<SupportedSPN> spns;
 
+    private List<SupportedSPN> freezeFrameSPNs;
+
     public DM24SPNSupportPacket(Packet packet) {
         super(packet, new J1939DaRepository().findPgnDefinition(PGN));
     }
@@ -67,6 +69,20 @@ public class DM24SPNSupportPacket extends GenericPacket {
             spns.sort(Comparator.comparingInt(SupportedSPN::getSpn));
         }
         return spns;
+    }
+
+    public List<SupportedSPN> getFreezeFrameSPNsInOrder() {
+        if (freezeFrameSPNs == null) {
+            freezeFrameSPNs = new ArrayList<>();
+            final int length = getPacket().getLength();
+            for (int i = 0; i + 3 < length; i = i + 4) {
+                final SupportedSPN parsedSpn = parseSpn(i);
+                if (parsedSpn.getSpn() != 0 && parsedSpn.supportsExpandedFreezeFrame()) {
+                    freezeFrameSPNs.add(parsedSpn);
+                }
+            }
+        }
+        return freezeFrameSPNs;
     }
 
     /**

--- a/src/org/etools/j1939_84/bus/j1939/packets/DM25ExpandedFreezeFrame.java
+++ b/src/org/etools/j1939_84/bus/j1939/packets/DM25ExpandedFreezeFrame.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.etools.j1939_84.bus.Packet;
+import org.etools.j1939_84.utils.CollectionUtils;
 
 /**
  * The {@link ParsedPacket} for Expanded Freeze Frame Codes (DM25)
@@ -17,6 +18,16 @@ import org.etools.j1939_84.bus.Packet;
  */
 public class DM25ExpandedFreezeFrame extends GenericPacket {
     public static final int PGN = 64951; //0xFDB7
+
+    public static DM25ExpandedFreezeFrame create(int sourceAddress, FreezeFrame... freezeFrames) {
+
+        int[] data = new int[0];
+        for (FreezeFrame freezeFrame : freezeFrames) {
+            data = CollectionUtils.join(data, freezeFrame.getData());
+        }
+
+        return new DM25ExpandedFreezeFrame(Packet.create(PGN, sourceAddress, data));
+    }
 
     private List<FreezeFrame> freezeFrames;
 
@@ -46,7 +57,7 @@ public class DM25ExpandedFreezeFrame extends GenericPacket {
         boolean done = false;
         while (!done) {
 
-            int[] bytes = getPacket().getData(index + 1, index + chunkLength);
+            int[] bytes = getPacket().getData(index + 1, index + chunkLength + 1);
             DiagnosticTroubleCode dtc = new DiagnosticTroubleCode(bytes);
             int[] data = Arrays.copyOfRange(bytes, 4, bytes.length);
             FreezeFrame freezeFrame = new FreezeFrame(dtc, data);

--- a/src/org/etools/j1939_84/bus/j1939/packets/FreezeFrame.java
+++ b/src/org/etools/j1939_84/bus/j1939/packets/FreezeFrame.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2019. Equipment & Tool Institute
  */
 package org.etools.j1939_84.bus.j1939.packets;
@@ -6,17 +6,30 @@ package org.etools.j1939_84.bus.j1939.packets;
 import static org.etools.j1939_84.J1939_84.NL;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Collectors;
+import org.etools.j1939_84.bus.j1939.packets.model.Spn;
+import org.etools.j1939_84.utils.CollectionUtils;
 
 /**
  * @author Marianne Schaefer (marianne.m.schaefer@gmail.com)
- *
  */
 public class FreezeFrame {
+
+    private List<Spn> spns;
 
     private final DiagnosticTroubleCode dtc;
 
     private final int[] spnData;
+
+    public FreezeFrame(DiagnosticTroubleCode dtc, Spn... spns) {
+        this(dtc, Arrays.asList(spns));
+    }
+
+    public FreezeFrame(DiagnosticTroubleCode dtc, List<Spn> spns) {
+        this.dtc = dtc;
+        this.spnData = spns.stream().flatMapToInt(s -> Arrays.stream(s.getData())).toArray();
+    }
 
     public FreezeFrame(DiagnosticTroubleCode dtc, int[] spnData) {
         this.dtc = dtc;
@@ -31,13 +44,43 @@ public class FreezeFrame {
         return spnData;
     }
 
+    public int[] getData() {
+        int[] joinedData = CollectionUtils.join(dtc.getData(), spnData);
+        return CollectionUtils.join(new int[] { joinedData.length }, joinedData);
+    }
+
+    public List<Spn> getSPNs() {
+        return spns;
+    }
+
+    public void setSPNs(List<Spn> spns) {
+        this.spns = spns;
+    }
+
+    public Spn getSpn(int spnId) {
+        return getSPNs().stream().filter(s -> s.getId() == spnId).findFirst().orElse(null);
+    }
+
     @Override
     public String toString() {
-        String result = "";
-        result += dtc + NL;
-        result += "SPN Data: "
-                + Arrays.stream(spnData).mapToObj(x -> String.format("%02X", x)).collect(Collectors.joining(" "));
-        return result;
+        StringBuilder result = new StringBuilder("Freeze Frame: {");
+        result.append(NL);
+        result.append(dtc).append(NL);
+        result.append("SPN Data: ")
+                .append(Arrays.stream(spnData)
+                                .mapToObj(x -> String.format("%02X", x))
+                                .collect(Collectors.joining(" "))).append(NL);
+
+        List<Spn> spns = getSPNs();
+        if (spns != null) {
+            for (Spn spn : spns) {
+                result.append(spn.toString()).append(NL);
+            }
+        }
+
+        result.append("}");
+
+        return result.toString();
     }
 
 }

--- a/src/org/etools/j1939_84/bus/j1939/packets/GenericPacket.java
+++ b/src/org/etools/j1939_84/bus/j1939/packets/GenericPacket.java
@@ -6,7 +6,6 @@ package org.etools.j1939_84.bus.j1939.packets;
 import static org.etools.j1939_84.J1939_84.NL;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.etools.j1939_84.bus.Packet;
@@ -18,27 +17,21 @@ import org.etools.j1939_84.bus.j1939.packets.model.SpnDefinition;
 
 public class GenericPacket extends ParsedPacket {
 
-    private static final PgnDefinition UNKNOWN_PGN = new PgnDefinition(-1,
-                                                                       "Unknown",
-                                                                       "UKN",
-                                                                       false,
-                                                                       false,
-                                                                       0,
-                                                                       Collections.emptyList());
     private final SpnDataParser parser;
     private final PgnDefinition pgnDefinition;
     private List<Spn> spns;
 
     public GenericPacket(Packet packet) {
-        this(packet, J1939DaRepository.getInstance().findPgnDefinition(packet.getPgn()));
+        this(packet, getJ1939DaRepository().findPgnDefinition(packet.getPgn()));
     }
+
     public GenericPacket(Packet packet, PgnDefinition pgnDefinition) {
         this(packet, pgnDefinition, new SpnDataParser());
     }
 
     GenericPacket(Packet packet, PgnDefinition pgnDefinition, SpnDataParser parser) {
         super(packet);
-        this.pgnDefinition = pgnDefinition == null ? UNKNOWN_PGN : pgnDefinition;
+        this.pgnDefinition = pgnDefinition;
         this.parser = parser;
     }
 
@@ -66,11 +59,9 @@ public class GenericPacket extends ParsedPacket {
             List<SpnDefinition> spnDefinitions = getPgnDefinition().getSpnDefinitions();
             byte[] bytes = getPacket().getBytes();
             for (SpnDefinition definition : spnDefinitions) {
-                Slot slot = Slot.findSlot(definition.getSlotNumber());
-                if (slot != null) {
-                    byte[] data = parser.parse(bytes, definition, slot.getLength());
-                    spns.add(new Spn(definition.getSpnId(), definition.getLabel(), slot, data));
-                }
+                Slot slot = getJ1939DaRepository().findSLOT(definition.getSlotNumber());
+                byte[] data = parser.parse(bytes, definition, slot.getLength());
+                spns.add(new Spn(definition.getSpnId(), definition.getLabel(), slot, data));
             }
         }
         return spns;
@@ -84,6 +75,10 @@ public class GenericPacket extends ParsedPacket {
             result.append("  ").append(spn.toString()).append(NL);
         }
         return result.toString();
+    }
+
+    private static J1939DaRepository getJ1939DaRepository() {
+        return J1939DaRepository.getInstance();
     }
 
 }

--- a/src/org/etools/j1939_84/bus/j1939/packets/ScaledTestResult.java
+++ b/src/org/etools/j1939_84/bus/j1939/packets/ScaledTestResult.java
@@ -8,6 +8,7 @@ import static org.etools.j1939_84.utils.CollectionUtils.join;
 
 import java.util.Arrays;
 import org.etools.j1939_84.NumberFormatter;
+import org.etools.j1939_84.bus.j1939.J1939DaRepository;
 
 /**
  * Represents a Scaled Test Result from a {@link DM30ScaledTestResultsPacket}
@@ -136,7 +137,7 @@ public class ScaledTestResult {
      */
     public Slot getSlot() {
         if (slot == null) {
-            slot = Slot.findSlot(slotNumber);
+            slot = J1939DaRepository.findSlot(slotNumber);
         }
         return slot;
     }

--- a/src/org/etools/j1939_84/bus/j1939/packets/Slot.java
+++ b/src/org/etools/j1939_84/bus/j1939/packets/Slot.java
@@ -3,19 +3,8 @@
  */
 package org.etools.j1939_84.bus.j1939.packets;
 
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 import java.util.Locale;
-import java.util.Map;
-import java.util.logging.Level;
-
-import org.etools.j1939_84.J1939_84;
-import org.etools.j1939_84.resources.Resources;
-
-import com.opencsv.CSVReader;
-import com.opencsv.CSVReaderBuilder;
 
 /**
  * Defines an SAE SLOT (Scaling, Limit, Offset, and Transfer Function)
@@ -24,111 +13,15 @@ import com.opencsv.CSVReaderBuilder;
  */
 public class Slot {
 
-    /**
-     * The Map of SLOT ID to Slot for lookups
-     */
-    private static Map<Integer, Slot> slots;
-
-    /**
-     * Helper method to convert from the given {@link String} to a double
-     *
-     * @param string
-     *            the {@link String} to convert
-     * @return Double or null if the string cannot be converted
-     */
-    private static Double doubleValue(String string) {
-        try {
-            return Double.parseDouble(string);
-        } catch (NumberFormatException e) {
-            return null;
-        }
-    }
-
-    /**
-     * Finds a SLOT given the Identifier of the SLOT
-     *
-     * @param id
-     *            the Identifier of the SLOT
-     * @return a SLOT or null if not found
-     */
-    public static Slot findSlot(int id) {
-        return getSlots().get(id);
-    }
-
-    /**
-     * Caches and returns all known {@link Slot}s
-     *
-     * @return a Map of SLOT ID to Slot
-     */
-    private static Map<Integer, Slot> getSlots() {
-        if (slots == null) {
-            slots = loadSlots();
-
-        }
-        return slots;
-    }
-
-    /**
-     * Helper method to convert from the given {@link String} to an int
-     *
-     * @param string
-     *            the {@link String} to convert
-     * @return int
-     */
-    private static int intValue(String string) {
-        try {
-            return Integer.parseInt(string);
-        } catch (NumberFormatException e) {
-            return -1;
-        }
-    }
-
-    /**
-     * Read the slots.csv file which contains all the SLOTs
-     *
-     * @return Map of SLOT ID to Slot
-     */
-    private static Map<Integer, Slot> loadSlots() {
-        Map<Integer, Slot> slots = new HashMap<>();
-        String[] values;
-
-        final InputStream is = Resources.class.getResourceAsStream("j1939da-slots.csv");
-        final InputStreamReader isReader = new InputStreamReader(is, StandardCharsets.UTF_8);
-        try (CSVReader reader = new CSVReaderBuilder(isReader)
-                .withSkipLines(2)
-                .build()) {
-            while ((values = reader.readNext()) != null) {
-                final int id = Integer.parseInt(values[0]);
-                final String name = values[1];
-                final String type = values[2];
-                final Double scaling = doubleValue(values[3]);
-                final String unit = values[4];
-                final Double offset = doubleValue(values[5]);
-                final int length = intValue(values[6]);
-                Slot slot = new Slot(id, name, type, scaling, offset, unit, length);
-                slots.put(id, slot);
-            }
-        } catch (Exception e) {
-            J1939_84.getLogger().log(Level.SEVERE, "Error loading map from slots", e);
-        }
-        return slots;
-    }
-
     private final int id;
-
     private final int length; // bits
-
     private final String name;
-
     private final Double offset;
-
     private final Double scaling;
-
     private final String type;
-
     private final String unit;
 
-    private Slot(int id, String name, String type, Double scaling, Double offset, String unit, int length) {
+    public Slot(int id, String name, String type, Double scaling, Double offset, String unit, int length) {
         this.id = id;
         this.name = name;
         this.type = type;
@@ -143,7 +36,7 @@ public class Slot {
      * applicable)
      *
      * @param data
-     *            the byte array containing the data from the packet
+     *         the byte array containing the data from the packet
      * @return a String of the value with units of measure
      */
     public String asString(byte[] data) {
@@ -186,7 +79,7 @@ public class Slot {
      * NOT_AVAILABLE or ERROR, null is returned
      *
      * @param data
-     *            the byte array containing the data from the packet
+     *         the byte array containing the data from the packet
      * @return the scaled value or null
      */
     public Double asValue(byte[] data) {
@@ -207,73 +100,54 @@ public class Slot {
         return scale(value);
     }
 
-    private long flipBytes(byte[] data, int byteLength) {
+    public byte[] asBytes(double value) {
+        if (isAscii()) {
+            return new byte[0];
+        }
+        double unscaled = unscale(value);
+        return toBytes(unscaled);
+    }
+
+    private long flipBytes(byte[] data) {
         long value = 0;
-        for (int i = 0; i < byteLength; i++) {
+        for (int i = 0; i < getByteLength(); i++) {
             value += ((long) (data[i] & 0xFF)) << i * 8;
         }
         return value;
     }
 
-    /**
-     * Returns the Identifier of the SLOT
-     *
-     * @return the id
-     */
+    private byte[] flipBytes(long value) {
+        byte[] bytes = new byte[getByteLength()];
+        for (int i = 0; i < getByteLength(); i++) {
+            bytes[i] += (byte) (value >> (i * 8)) & 0xFF;
+        }
+        return bytes;
+    }
+
     public int getId() {
         return id;
     }
 
-    /**
-     * Returns the length of the data in bits
-     *
-     * @return the length
-     */
     public int getLength() {
         return length;
     }
 
-    /**
-     * Returns the Name of the SLOT
-     *
-     * @return the name
-     */
     public String getName() {
         return name;
     }
 
-    /**
-     * Returns the offset
-     *
-     * @return the offset
-     */
     public Double getOffset() {
         return offset;
     }
 
-    /**
-     * Returns the scaling
-     *
-     * @return the scaling
-     */
     public Double getScaling() {
         return scaling;
     }
 
-    /**
-     * Returns the Type of the SLOT
-     *
-     * @return the type
-     */
     public String getType() {
         return type;
     }
 
-    /**
-     * Returns the Units of the SLOT
-     *
-     * @return the unit
-     */
     public String getUnit() {
         return unit;
     }
@@ -328,7 +202,7 @@ public class Slot {
      * Returns a scaled value. That is result = value * scaling + offset
      *
      * @param value
-     *            the value to scale
+     *         the value to scale
      * @return double
      */
     public double scale(double value) {
@@ -342,16 +216,39 @@ public class Slot {
         return result;
     }
 
+    private double unscale(double value) {
+        double result = value;
+        if (getOffset() != null) {
+            result -= getOffset();
+        }
+
+        if (getScaling() != null) {
+            result /= getScaling();
+        }
+        return result;
+    }
+
     private long toValue(byte[] data) {
         if (length <= 8) {
             return data[0] & 0xFF & mask();
         }
+        return flipBytes(data) & mask();
+    }
 
+    public int getByteLength() {
         int byteLength = length / 8;
         if (length % 8 != 0) {
             byteLength++;
         }
-        return flipBytes(data, byteLength) & mask();
+        return byteLength;
+    }
+
+    private byte[] toBytes(double value) {
+        long data = Double.valueOf(value).longValue();
+        if (length <= 8) {
+            return new byte[] { (byte) (data & mask()) };
+        }
+        return flipBytes(data & mask());
     }
 
 }

--- a/src/org/etools/j1939_84/bus/j1939/packets/model/Spn.java
+++ b/src/org/etools/j1939_84/bus/j1939/packets/model/Spn.java
@@ -3,7 +3,9 @@
  */
 package org.etools.j1939_84.bus.j1939.packets.model;
 
+import org.etools.j1939_84.bus.j1939.J1939DaRepository;
 import org.etools.j1939_84.bus.j1939.packets.Slot;
+import org.etools.j1939_84.utils.CollectionUtils;
 
 public class Spn {
 
@@ -11,6 +13,15 @@ public class Spn {
     private final String label;
     private final Slot slot;
     private final byte[] data;
+
+    public static Spn create(int id, double value) {
+        J1939DaRepository j1939DaRepository = J1939DaRepository.getInstance();
+        SpnDefinition spnDefinition = j1939DaRepository.findSpnDefinition(id);
+        String label = spnDefinition.getLabel();
+        Slot slot = j1939DaRepository.findSLOT(spnDefinition.getSlotNumber());
+        byte[] data = slot.asBytes(value);
+        return new Spn(id, label, slot, data);
+    }
 
     public Spn(int id, String label, Slot slot, byte[] data) {
         this.id = id;
@@ -23,6 +34,10 @@ public class Spn {
         return id;
     }
 
+    public int[] getData() {
+        return CollectionUtils.toIntArray(data);
+    }
+
     /**
      * Returns the scaled value of the data.
      * This will return null if the value is NOT_AVAILABLE or ERROR.
@@ -31,7 +46,11 @@ public class Spn {
      * @return Double or null
      */
     public Double getValue() {
-        return slot == null ? null : slot.asValue(data);
+        return slot.asValue(data);
+    }
+
+    public boolean hasValue() {
+        return getValue() != null;
     }
 
     /**
@@ -40,7 +59,7 @@ public class Spn {
      * @return boolean
      */
     public boolean isNotAvailable() {
-        return slot == null || slot.isNotAvailable(data);
+        return slot.isNotAvailable(data);
     }
 
     /**
@@ -49,7 +68,7 @@ public class Spn {
      * @return boolean
      */
     public boolean isError() {
-        return slot == null || slot.isError(data);
+        return slot.isError(data);
     }
 
     @Override
@@ -57,7 +76,7 @@ public class Spn {
         return String.format("SPN %1$5s, %2$s: %3$s",
                              id,
                              label,
-                             slot == null ? "" : slot.asString(data));
+                             slot.asString(data));
     }
 
 }

--- a/src/org/etools/j1939_84/controllers/FreezeFrameDataTranslator.java
+++ b/src/org/etools/j1939_84/controllers/FreezeFrameDataTranslator.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2021. Equipment & Tool Institute
+ */
+
+package org.etools.j1939_84.controllers;
+
+import static org.etools.j1939_84.J1939_84.getLogger;
+import static org.etools.j1939_84.utils.CollectionUtils.toByteArray;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
+import org.etools.j1939_84.bus.j1939.J1939DaRepository;
+import org.etools.j1939_84.bus.j1939.packets.FreezeFrame;
+import org.etools.j1939_84.bus.j1939.packets.Slot;
+import org.etools.j1939_84.bus.j1939.packets.SupportedSPN;
+import org.etools.j1939_84.bus.j1939.packets.model.Spn;
+import org.etools.j1939_84.bus.j1939.packets.model.SpnDefinition;
+
+public class FreezeFrameDataTranslator {
+
+    private final J1939DaRepository j1939DaRepository;
+
+    public FreezeFrameDataTranslator() {
+        this(J1939DaRepository.getInstance());
+    }
+
+    private FreezeFrameDataTranslator(J1939DaRepository j1939DaRepository) {
+        this.j1939DaRepository = j1939DaRepository;
+    }
+
+    /**
+     * Uses the data from the FreezeFrame and the list of Freeze Frame Supported SPNs
+     * to produce a List of SPNs which will have the data populated.
+     */
+    public List<Spn> getFreezeFrameSPNs(FreezeFrame freezeFrame, List<SupportedSPN> supportedSPNs) {
+        List<SupportedSPN> supportedFreezeFrameSPNs = supportedSPNs.stream()
+                .filter(SupportedSPN::supportsExpandedFreezeFrame)
+                .collect(Collectors.toList());
+
+        byte[] spnData = toByteArray(freezeFrame.getSpnData());
+
+        int expectedLength = supportedFreezeFrameSPNs.stream().mapToInt(SupportedSPN::getLength).sum();
+        int actualLength = spnData.length;
+        if (actualLength != expectedLength) {
+            getLogger().log(Level.SEVERE,
+                            "The expected (" + expectedLength + ") and actual (" + actualLength + ") data lengths are different");
+            return List.of();
+        }
+
+        List<Spn> spns = new ArrayList<>();
+        int index = 0;
+        for (SupportedSPN supportedSPN : supportedFreezeFrameSPNs) {
+            byte[] bytes = Arrays.copyOfRange(spnData, index, index + supportedSPN.getLength());
+            index += supportedSPN.getLength();
+
+            int spnId = supportedSPN.getSpn();
+            SpnDefinition spnDefinition = getSpnDefinition(spnId);
+            String label = spnDefinition.getLabel();
+            int slotNumber = spnDefinition.getSlotNumber();
+            Slot slot = getSlotDefinition(slotNumber);
+
+            spns.add(new Spn(spnId, label, slot, bytes));
+        }
+        return spns;
+    }
+
+    private SpnDefinition getSpnDefinition(int spnId) {
+        return j1939DaRepository.findSpnDefinition(spnId);
+    }
+
+    private Slot getSlotDefinition(int slotNumber) {
+        return j1939DaRepository.findSLOT(slotNumber);
+    }
+
+}

--- a/src/org/etools/j1939_84/controllers/TableA2ValueValidator.java
+++ b/src/org/etools/j1939_84/controllers/TableA2ValueValidator.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2021. Equipment & Tool Institute
+ */
+
+package org.etools.j1939_84.controllers;
+
+import static org.etools.j1939_84.model.Outcome.WARN;
+
+import java.util.List;
+import org.etools.j1939_84.bus.j1939.packets.FreezeFrame;
+import org.etools.j1939_84.bus.j1939.packets.model.Spn;
+
+public class TableA2ValueValidator {
+
+    private static final List<Integer> ENGINE_SPEED_SPNS = List.of(190, 4201, 723, 4202);
+    private static final List<Integer> TEMPERATURE_SPNS = List.of(110, 1637, 4076, 4193);
+
+    private final int partNumber;
+    private final int stepNumber;
+
+    public TableA2ValueValidator(int partNumber, int stepNumber) {
+        this.partNumber = partNumber;
+        this.stepNumber = stepNumber;
+    }
+
+    public void reportWarnings(FreezeFrame freezeFrame, ResultsListener listener, String section) {
+        for (int spnId : TEMPERATURE_SPNS) {
+            Spn spn = freezeFrame.getSpn(spnId);
+            Double value = spn == null ? null : spn.getValue();
+            if (value != null && (value < 7 || value > 110)) {
+                addWarning(listener,
+                           section,
+                           spn.toString() + " is < 7 C or > 110 C");
+            }
+        }
+
+        for (int spnId : ENGINE_SPEED_SPNS) {
+            Spn spn = freezeFrame.getSpn(spnId);
+            Double value = spn == null ? null : spn.getValue();
+            if (value != null && value <= 300) {
+                addWarning(listener, section, spn.toString() + " is <= 300 rpm");
+            }
+        }
+
+        Double engineSpeed = freezeFrame.getSPNs()
+                .stream()
+                .filter(s -> ENGINE_SPEED_SPNS.contains(s.getId()))
+                .filter(Spn::hasValue)
+                .map(Spn::getValue)
+                .findFirst()
+                .orElse(null);
+
+        if (engineSpeed == null) {
+            listener.onResult("Unable to confirm engine speed");
+        } else if (engineSpeed > 300) {
+            Spn spn = freezeFrame.getSpn(92);
+            Double value = spn == null ? null : spn.getValue();
+            if (value != null && value <= 0) {
+                addWarning(listener, section, spn.toString() + " is <= 0% with rpm > 300");
+            }
+
+            spn = freezeFrame.getSpn(512);
+            value = spn == null ? null : spn.getValue();
+            if (value != null && value < 0) {
+                addWarning(listener, section, spn.toString() + " is < 0% with rpm > 300");
+            }
+
+            spn = freezeFrame.getSpn(513);
+            value = spn == null ? null : spn.getValue();
+            if (value != null && value <= 0) {
+                addWarning(listener, section, spn.toString() + " is <= 0% with rpm > 300");
+            }
+
+            spn = freezeFrame.getSpn(3301);
+            value = spn == null ? null : spn.getValue();
+            if (value != null && value < 1) { // < 1 to account for the precision of using a Double
+                addWarning(listener,
+                           section,
+                           spn.toString() + " is = 0 seconds with rpm > 300");
+            }
+        }
+    }
+
+    private void addWarning(ResultsListener listener, String section, String message) {
+        listener.addOutcome(partNumber, stepNumber, WARN, section + " - " + message);
+        listener.onResult("WARN: " + message);
+    }
+
+}

--- a/src/org/etools/j1939_84/controllers/part03/Part03Step13Controller.java
+++ b/src/org/etools/j1939_84/controllers/part03/Part03Step13Controller.java
@@ -3,10 +3,24 @@
  */
 package org.etools.j1939_84.controllers.part03;
 
+import static org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket.Response.NACK;
+
+import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+import org.etools.j1939_84.bus.j1939.BusResult;
+import org.etools.j1939_84.bus.j1939.Lookup;
+import org.etools.j1939_84.bus.j1939.packets.DM24SPNSupportPacket;
+import org.etools.j1939_84.bus.j1939.packets.DM25ExpandedFreezeFrame;
+import org.etools.j1939_84.bus.j1939.packets.FreezeFrame;
+import org.etools.j1939_84.bus.j1939.packets.ParsedPacket;
+import org.etools.j1939_84.bus.j1939.packets.SupportedSPN;
 import org.etools.j1939_84.controllers.DataRepository;
+import org.etools.j1939_84.controllers.FreezeFrameDataTranslator;
 import org.etools.j1939_84.controllers.StepController;
+import org.etools.j1939_84.controllers.TableA2ValueValidator;
+import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
 import org.etools.j1939_84.modules.DiagnosticMessageModule;
@@ -22,6 +36,9 @@ public class Part03Step13Controller extends StepController {
     private static final int STEP_NUMBER = 13;
     private static final int TOTAL_STEPS = 0;
 
+    private final FreezeFrameDataTranslator translator;
+    private final TableA2ValueValidator validator;
+
     Part03Step13Controller() {
         this(Executors.newSingleThreadScheduledExecutor(),
              new BannerModule(),
@@ -29,7 +46,9 @@ public class Part03Step13Controller extends StepController {
              DataRepository.getInstance(),
              new EngineSpeedModule(),
              new VehicleInformationModule(),
-             new DiagnosticMessageModule());
+             new DiagnosticMessageModule(),
+             new FreezeFrameDataTranslator(),
+             new TableA2ValueValidator(PART_NUMBER, STEP_NUMBER));
     }
 
     Part03Step13Controller(Executor executor,
@@ -38,7 +57,9 @@ public class Part03Step13Controller extends StepController {
                            DataRepository dataRepository,
                            EngineSpeedModule engineSpeedModule,
                            VehicleInformationModule vehicleInformationModule,
-                           DiagnosticMessageModule diagnosticMessageModule) {
+                           DiagnosticMessageModule diagnosticMessageModule,
+                           FreezeFrameDataTranslator translator,
+                           TableA2ValueValidator validator) {
         super(executor,
               bannerModule,
               dateTimeModule,
@@ -49,22 +70,126 @@ public class Part03Step13Controller extends StepController {
               PART_NUMBER,
               STEP_NUMBER,
               TOTAL_STEPS);
+        this.translator = translator;
+        this.validator = validator;
     }
 
     @Override
     protected void run() throws Throwable {
         // 6.3.13.1.a. DS DM25 (send Request (PGN 59904) for PGN 64951 (SPNs 3300, 1214-1215)) to each OBD ECU.
-        // 6.3.13.1.b. If no response (transport protocol RTS or NACK(Busy) in 220 ms), then retry DS DM25 request to the OBD ECU. [Do not attempt retry for NACKS that indicate not supported]
-        // 6.3.13.1.c. Translate and print in log file all received freeze frame data with data labels assuming data received in order expected by DM24 response for visual check by test log reviewer.
+        var responses = getDataRepository().getObdModuleAddresses()
+                .stream()
+                .map(address -> getDiagnosticMessageModule().requestDM25(getListener(), address))
+                .map(BusResult::requestResult)
+                .collect(Collectors.toList());
+
+        // 6.3.13.1.b. If no response (transport protocol RTS or NACK(Busy) in 220 ms), then retry DS DM25 request to the OBD ECU.
+        // [Do not attempt retry for NACKS that indicate not supported]
+        var responseAddresses = filterRequestResultPackets(responses)
+                .stream()
+                .map(ParsedPacket::getSourceAddress)
+                .collect(Collectors.toSet());
+
+        var nackAddresses = filterRequestResultAcks(responses)
+                .stream()
+                .filter(r -> r.getResponse() == NACK)
+                .map(ParsedPacket::getSourceAddress)
+                .collect(Collectors.toSet());
+
+        List<Integer> missingAddresses = getDataRepository().getObdModuleAddresses();
+        missingAddresses.removeAll(responseAddresses);
+        missingAddresses.removeAll(nackAddresses);
+
+        missingAddresses.stream()
+                .map(address -> getDiagnosticMessageModule().requestDM25(getListener(), address))
+                .map(BusResult::requestResult)
+                .forEach(responses::add);
 
         // 6.3.13.2.a. Fail if retry was required to obtain DM25 response.
+        missingAddresses.stream()
+                .map(Lookup::getAddressName)
+                .forEach(moduleName -> addFailure("6.3.13.2.a - Retry was required to obtain DM25 response from " + moduleName));
+
+        List<DM25ExpandedFreezeFrame> packets = filterRequestResultPackets(responses);
+
+        // 6.3.13.1.c. Translate and print in log file all received freeze frame data with data labels assuming data
+        // received in order expected by DM24 response for visual check by test log reviewer.
+        for (OBDModuleInformation moduleInformation : getDataRepository().getObdModules()) {
+            DM24SPNSupportPacket dm24 = moduleInformation.getDm24();
+            if (dm24 == null) {
+                continue;
+            }
+
+            List<SupportedSPN> supportedSPNs = dm24.getFreezeFrameSPNsInOrder();
+            int moduleAddress = moduleInformation.getSourceAddress();
+            String moduleName = Lookup.getAddressName(moduleAddress);
+
+            packets.stream()
+                    .filter(p -> p.getSourceAddress() == moduleAddress)
+                    .findFirst()
+                    .ifPresent(p -> {
+                        for (FreezeFrame freezeFrame : p.getFreezeFrames()) {
+                            freezeFrame.setSPNs(translator.getFreezeFrameSPNs(freezeFrame, supportedSPNs));
+                            getListener().onResult("6.3.13.1.c - Received from " + moduleName + ": ");
+                            getListener().onResult(freezeFrame.toString());
+                            getListener().onResult("");
+
+                            // 6.3.13.2.e. Fail/warn per section A.2, Criteria for Freeze Frame Evaluation.
+                            validator.reportWarnings(freezeFrame, getListener(), "6.3.13.2.e");
+                        }
+                    });
+        }
+
         // 6.3.13.2.b. Fail if no ECU has freeze frame data to report.
+        boolean freezeFrameReceived = packets.stream().anyMatch(p -> !p.getFreezeFrames().isEmpty());
+        if (!freezeFrameReceived) {
+            addFailure("6.3.13.2.b - No ECU has freeze frame data to report");
+        }
+
         // 6.3.13.2.c. Fail if received data does not match expected number of bytes based on DM24 supported SPN list for that ECU.
-        // 6.3.13.2.d. Fail if freeze frame data does not include the same SPN+FMI as DM6 pending DTC earlier in this part.37
-        // 6.3.13.2.e. Fail/warn per section A.2, Criteria for Freeze Frame Evaluation.
+        for (DM25ExpandedFreezeFrame dm25 : packets) {
+            String moduleName = dm25.getModuleName();
+            int expectedLength = getDataRepository().getObdModule(dm25.getSourceAddress())
+                    .getFreezeFrameSpns()
+                    .stream()
+                    .mapToInt(SupportedSPN::getLength)
+                    .sum();
+            for (FreezeFrame freezeFrame : dm25.getFreezeFrames()) {
+                int actualLength = freezeFrame.getSpnData().length;
+                if (expectedLength != actualLength) {
+                    addFailure(
+                            "6.3.13.2.c - Received data (" + actualLength + ") does not match expected number of bytes (" + expectedLength + ") based on DM24 supported SPN list for " + moduleName);
+                }
+            }
+        }
+
+        // 6.3.13.2.d. Fail if freeze frame data does not include the same SPN+FMI as DM6 pending DTC earlier in this part.
+        for (DM25ExpandedFreezeFrame dm25 : packets) {
+            var pendingDTCs = getDataRepository().getObdModule(dm25.getSourceAddress())
+                    .getEmissionDTCs()
+                    .stream()
+                    .map(dtc -> dtc.getSuspectParameterNumber() + ":" + dtc.getFailureModeIndicator())
+                    .collect(Collectors.toList());
+            dm25.getFreezeFrames()
+                    .stream()
+                    .map(FreezeFrame::getDtc)
+                    .map(dtc -> dtc.getSuspectParameterNumber() + ":" + dtc.getFailureModeIndicator())
+                    .forEach(pendingDTCs::remove);
+
+            if (!pendingDTCs.isEmpty()) {
+                addFailure("6.3.13.2.d - Freeze frame data from " + dm25.getModuleName() + " does not include the same SPN+FMI as DM6 Pending DTC earlier in this part.");
+            }
+        }
 
         // 6.3.13.2.f. Warn if more than 1 freeze frame data set is included in the response.
+        packets.stream()
+                .filter(p -> p.getFreezeFrames().size() > 1)
+                .map(ParsedPacket::getModuleName)
+                .forEach(moduleName -> addWarning(
+                        "6.3.13.2.e - More than 1 freeze frame data set is included in the response from " + moduleName));
+
         // 6.3.13.2.g. Fail if NACK not received from OBD ECUs that did not provide DM25 response to query.
+        checkForNACKsFromObdModules(packets, filterRequestResultAcks(responses), "6.3.13.2.g");
     }
 
 }

--- a/src/org/etools/j1939_84/model/OBDModuleInformation.java
+++ b/src/org/etools/j1939_84/model/OBDModuleInformation.java
@@ -14,6 +14,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.etools.j1939_84.bus.j1939.packets.DM19CalibrationInformationPacket.CalibrationInformation;
+import org.etools.j1939_84.bus.j1939.packets.DM24SPNSupportPacket;
 import org.etools.j1939_84.bus.j1939.packets.DM25ExpandedFreezeFrame;
 import org.etools.j1939_84.bus.j1939.packets.DM26TripDiagnosticReadinessPacket;
 import org.etools.j1939_84.bus.j1939.packets.DM27AllPendingDTCsPacket;
@@ -58,6 +59,8 @@ public class OBDModuleInformation implements Cloneable {
 
     private DM27AllPendingDTCsPacket lastDM27;
 
+    private DM24SPNSupportPacket dm24;
+
     private final List<DiagnosticTroubleCode> emissionDTCs = new ArrayList<>();
 
     /** These SPNs represent SP which appear in multiple PGs. */
@@ -88,6 +91,7 @@ public class OBDModuleInformation implements Cloneable {
         obdInfo.setLastDM26(getLastDM26());
         obdInfo.setLastDM27(getLastDM27());
         obdInfo.setEmissionDTCs(getEmissionDTCs());
+        obdInfo.setDm24(getDm24());
 
         return obdInfo;
     }
@@ -119,7 +123,8 @@ public class OBDModuleInformation implements Cloneable {
                 && Objects.equals(lastDM25, that.lastDM25)
                 && Objects.equals(lastDM26, that.lastDM26)
                 && Objects.equals(lastDM27, that.lastDM27)
-                && Objects.equals(emissionDTCs, that.emissionDTCs);
+                && Objects.equals(emissionDTCs, that.emissionDTCs)
+                && Objects.equals(dm24, that.dm24);
     }
 
     public int getIgnitionCycleCounterValue() {
@@ -192,7 +197,7 @@ public class OBDModuleInformation implements Cloneable {
     }
 
     public List<SupportedSPN> getSupportedSpns() {
-        return supportedSpns.stream()
+        return (dm24 == null ? supportedSpns : dm24.getSupportedSpns()).stream()
                 .sorted(Comparator.comparingInt(SupportedSPN::getSpn))
                 .collect(Collectors.toList());
     }
@@ -219,7 +224,8 @@ public class OBDModuleInformation implements Cloneable {
                             lastDM25,
                             lastDM26,
                             lastDM27,
-                            emissionDTCs);
+                            emissionDTCs,
+                            dm24);
     }
 
     public void setCalibrationInformation(List<CalibrationInformation> calibrationInformation) {
@@ -306,6 +312,14 @@ public class OBDModuleInformation implements Cloneable {
     public void setEmissionDTCs(List<DiagnosticTroubleCode> emissionDTCs) {
         this.emissionDTCs.clear();
         this.emissionDTCs.addAll(emissionDTCs);
+    }
+
+    public DM24SPNSupportPacket getDm24() {
+        return dm24;
+    }
+
+    public void setDm24(DM24SPNSupportPacket dm24) {
+        this.dm24 = dm24;
     }
 
     @Override

--- a/src/org/etools/j1939_84/utils/CollectionUtils.java
+++ b/src/org/etools/j1939_84/utils/CollectionUtils.java
@@ -75,4 +75,21 @@ public class CollectionUtils {
             return joinedArray;
         }
     }
+
+    public static int[] toIntArray(byte[] bytes) {
+        int[] array = new int[bytes.length];
+        for (int i = 0; i < array.length; i++) {
+            array[i] = bytes[i] & 0xFF;
+        }
+        return array;
+    }
+
+    public static byte[] toByteArray(int[] data) {
+        byte[] bytes = new byte[data.length];
+        for (int i = 0; i < data.length; i++) {
+            bytes[i] = (byte) (data[i] & 0xFF);
+        }
+        return bytes;
+    }
+
 }


### PR DESCRIPTION
In additional to implementing Part 3 Step 13, I also found a latent bug in DM25 message parsing.  We didn't count the number of bytes right.  That's fixed.  I had to go back to Part 1 Step 4 to save the entire DM24 response the exact order of the Freeze Frame SPNs was required to parse the DM25.

Speaking of DM25, this review (at this moment) has a shortcoming with SPN 3301.  Since SPN 3301 is defined in /73, the details are not included in -DA.  Therefore, it displays as the value given with no scaling or offset (which works for now as the scaling is 1 and the offset is 0).  But this will be addressed with changes from @battjt .

I split `Slot` to move the repository part into `J1939DaRespository`. Additionally, the 'find' methods in the repository will return default data structures to avoid null checks throughout the code.