### PR TITLE
Fix #287 Implement Part 4 Step 2

### DIFF
--- a/src-test/org/etools/j1939_84/controllers/TestResultsListener.java
+++ b/src-test/org/etools/j1939_84/controllers/TestResultsListener.java
@@ -7,6 +7,7 @@ import static org.etools.j1939_84.J1939_84.NL;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.etools.j1939_84.model.ActionOutcome;
 import org.etools.j1939_84.model.Outcome;
 import org.etools.j1939_84.model.PartResult;
 import org.etools.j1939_84.model.StepResult;
@@ -32,6 +33,8 @@ public class TestResultsListener implements ResultsListener {
 
     private boolean success;
 
+    private final List<ActionOutcome> outcomes = new ArrayList<>();
+
     public TestResultsListener() {
         this(null);
     }
@@ -42,6 +45,7 @@ public class TestResultsListener implements ResultsListener {
 
     @Override
     public void addOutcome(int partNumber, int stepNumber, Outcome outcome, String message) {
+        outcomes.add(new ActionOutcome(outcome, message));
         mockListener.addOutcome(partNumber, stepNumber, outcome, message);
     }
 
@@ -140,7 +144,10 @@ public class TestResultsListener implements ResultsListener {
     @Override
     public void onVehicleInformationReceived(VehicleInformation vehicleInformation) {
         mockListener.onVehicleInformationReceived(vehicleInformation);
+    }
 
+    public List<ActionOutcome> getOutcomes() {
+        return outcomes;
     }
 
 }

--- a/src/org/etools/j1939_84/bus/simulated/Engine.java
+++ b/src/org/etools/j1939_84/bus/simulated/Engine.java
@@ -219,7 +219,12 @@ public class Engine implements AutoCloseable {
 
         // DM12
         sim.response(p -> isRequestFor(DM12MILOnEmissionDTCPacket.PGN, p),
-                     () -> Packet.create(DM12MILOnEmissionDTCPacket.PGN, ADDR, 0x00, 0x00, 0x00, 0x00, 0x00));
+                     () -> DM12MILOnEmissionDTCPacket.create(0,
+                                                              ON,
+                                                              OFF,
+                                                              ON,
+                                                              ON,
+                                                              DiagnosticTroubleCode.create(123, 12, 0, 1)).getPacket());
 
         // DM23
         sim.response(p -> isRequestFor(64949, p), () -> Packet.create(64949, ADDR, 0x00, 0x00, 0x00, 0x00, 0x00));

--- a/src/org/etools/j1939_84/controllers/StepController.java
+++ b/src/org/etools/j1939_84/controllers/StepController.java
@@ -29,6 +29,7 @@ import org.etools.j1939_84.bus.j1939.Lookup;
 import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket;
 import org.etools.j1939_84.bus.j1939.packets.CompositeSystem;
 import org.etools.j1939_84.bus.j1939.packets.DiagnosticReadinessPacket;
+import org.etools.j1939_84.bus.j1939.packets.DiagnosticTroubleCode;
 import org.etools.j1939_84.bus.j1939.packets.GenericPacket;
 import org.etools.j1939_84.bus.j1939.packets.MonitoredSystem;
 import org.etools.j1939_84.bus.j1939.packets.ParsedPacket;
@@ -337,6 +338,13 @@ public abstract class StepController extends Controller {
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .collect(Collectors.toList());
+    }
+
+    protected static String toString(List<DiagnosticTroubleCode> dtcs) {
+        return dtcs.stream()
+                .map(d -> d.getSuspectParameterNumber() + ":" + d.getFailureModeIndicator())
+                .sorted()
+                .collect(Collectors.joining(","));
     }
 
 }

--- a/src/org/etools/j1939_84/controllers/part01/Part01Step08Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step08Controller.java
@@ -23,6 +23,7 @@ import org.etools.j1939_84.modules.VehicleInformationModule;
 
 /**
  * 6.1.8 DM20: Monitor Performance Ratio
+ *
  * @author Garrison Garland (garrison@soliddesign.net)
  */
 public class Part01Step08Controller extends StepController {
@@ -81,7 +82,8 @@ public class Part01Step08Controller extends StepController {
     protected void run() throws Throwable {
 
         // 6.1.8.1.a. Global DM20 (send Request (PGN 59904) for PGN 49664
-        List<DM20MonitorPerformanceRatioPacket> globalDM20s = getDiagnosticMessageModule().requestDM20(getListener()).getPackets();
+        List<DM20MonitorPerformanceRatioPacket> globalDM20s = getDiagnosticMessageModule().requestDM20(getListener())
+                .getPackets();
 
         // 6.1.8.1 Actions:
         // 6.1.8.1.a.i. Create list of ECU address
@@ -118,14 +120,14 @@ public class Part01Step08Controller extends StepController {
             List<Integer> SPNa = new ArrayList<>(List.of(5322, 5318, 3058, 3064, 5321, 3055));
             SPNa.removeAll(dm20Spns);
             if (!SPNa.isEmpty()) {
-                msg += " Not Supported SPNs: " + toString(SPNa);
+                msg += " Not Supported SPNs: " + spnToString(SPNa);
                 failure = true;
             }
 
             List<Integer> SPNn = new ArrayList<>(List.of(4792, 5308, 4364));
             SPNn.removeAll(dm20Spns);
             if (SPNn.size() == 3) {
-                msg += " None of these SPNs are supported: " + toString(SPNn);
+                msg += " None of these SPNs are supported: " + spnToString(SPNn);
                 failure = true;
             }
         } else if (fuelType.isSparkIgnition()) {
@@ -134,7 +136,7 @@ public class Part01Step08Controller extends StepController {
             List<Integer> SPNsi = new ArrayList<>(List.of(3054, 3058, 3306, 3053, 3050, 3051, 3055, 3056, 3057));
             SPNsi.removeAll(dm20Spns);
             if (!SPNsi.isEmpty()) {
-                msg += " Not Supported SPNs: " + toString(SPNsi);
+                msg += " Not Supported SPNs: " + spnToString(SPNsi);
                 failure = true;
             }
         } else {
@@ -145,7 +147,7 @@ public class Part01Step08Controller extends StepController {
         }
     }
 
-    private static String toString(List<Integer> spns) {
+    private static String spnToString(List<Integer> spns) {
         return spns.stream().map(i -> "" + i).sorted().collect(Collectors.joining(", "));
     }
 }

--- a/src/org/etools/j1939_84/controllers/part04/Part04Step02Controller.java
+++ b/src/org/etools/j1939_84/controllers/part04/Part04Step02Controller.java
@@ -3,10 +3,26 @@
  */
 package org.etools.j1939_84.controllers.part04;
 
+import static org.etools.j1939_84.J1939_84.NL;
+import static org.etools.j1939_84.bus.j1939.packets.LampStatus.ON;
+import static org.etools.j1939_84.controllers.ResultsListener.MessageType.QUESTION;
+
+import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+import org.etools.j1939_84.bus.j1939.BusResult;
+import org.etools.j1939_84.bus.j1939.Lookup;
+import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket;
+import org.etools.j1939_84.bus.j1939.packets.DM12MILOnEmissionDTCPacket;
+import org.etools.j1939_84.bus.j1939.packets.DM6PendingEmissionDTCPacket;
+import org.etools.j1939_84.bus.j1939.packets.DiagnosticTroubleCode;
+import org.etools.j1939_84.bus.j1939.packets.DiagnosticTroubleCodePacket;
+import org.etools.j1939_84.bus.j1939.packets.ParsedPacket;
 import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
+import org.etools.j1939_84.model.OBDModuleInformation;
+import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
 import org.etools.j1939_84.modules.DiagnosticMessageModule;
@@ -52,16 +68,119 @@ public class Part04Step02Controller extends StepController {
 
     @Override
     protected void run() throws Throwable {
-        // 6.4.2.1.a. Global DM12 ([send Request (PGN 59904) for PGN 65236 (SPN 1213-1215, 1706, and 3038)]) to retrieve confirmed and active DTCs.
-        // 6.4.2.1.a.i. Repeat request no more frequently than once per second until one or more ECUs reports a confirmed and active DTC.
-        // 6.4.2.1.a.ii. Time-out after every 5 minutes and ask user “‘yes/no”’ to continue if there is still no confirmed and active DTC; fail if user says “'no”' and no ECU reports a confirmed and active DTC.
+
+        int attempts = 0;
+        List<DM12MILOnEmissionDTCPacket> globalPackets = List.of();
+        boolean foundDTC = false;
+        while (!foundDTC) {
+            // 6.4.2.1.a. Global DM12 ([send Request (PGN 59904) for PGN 65236 (SPN 1213-1215, 1706, and 3038)])
+            //   to retrieve confirmed and active DTCs.
+
+            // 6.4.2.1.a.i. Repeat request no more frequently than once per second until one or more ECUs
+            //   reports a confirmed and active DTC.
+
+            attempts++;
+            updateProgress("Step 4.2. Requesting DM12 Attempt " + attempts);
+
+            getListener().onResult(NL + "Attempt " + attempts);
+            globalPackets = getDiagnosticMessageModule().requestDM12(getListener()).getPackets();
+
+            foundDTC = globalPackets.stream()
+                    .map(DiagnosticTroubleCodePacket::getDtcs)
+                    .map(dtcs -> !dtcs.isEmpty())
+                    .findFirst()
+                    .orElse(false);
+
+            if (!foundDTC) {
+                if (attempts == 5 * 60) {
+                    // 6.4.2.1.a.ii. Time-out after every 5 minutes
+                    // and ask user “‘yes/no”’ to continue if there is still no confirmed and active DTC;
+                    // fail if user says “'no”' and no ECU reports a confirmed and active DTC.
+
+                    // This will throw an exception if the user chooses 'no'
+                    displayInstructionAndWait("No module has reported a confirmed and active DTC." + NL +
+                                                      "Do you wish to continue?",
+                                              "No Confirmed and Active DTCs Found",
+                                              QUESTION);
+                    attempts = 0;
+                } else {
+                    getDateTimeModule().pauseFor(1000);
+                }
+            }
+        }
+
+        //Save the DTCs per module
+        globalPackets.stream()
+                .filter(p -> getDataRepository().isObdModule(p.getSourceAddress()))
+                .filter(p -> !p.getDtcs().isEmpty())
+                .forEach(p -> {
+                    var moduleInfo = getDataRepository().getObdModule(p.getSourceAddress());
+                    moduleInfo.set(p);
+                    getDataRepository().putObdModule(moduleInfo);
+                });
+
         // 6.4.2.2.a. Fail if no ECU reports MIL on. See Section A.8 for allowed values.
+        boolean isMILOn = globalPackets.stream().anyMatch(p -> p.getMalfunctionIndicatorLampStatus() == ON);
+        if (!isMILOn) {
+            addFailure("6.4.2.2.a - No ECU reported MIL on");
+        }
+
         // 6.4.2.2.b. Fail if DM12 DTC(s) is (are) not the same SPN+FMI(s) as DM6 pending DTC in part 3.
+        for (OBDModuleInformation moduleInfo : getDataRepository().getObdModules()) {
+            int moduleAddress = moduleInfo.getSourceAddress();
+            String moduleName = Lookup.getAddressName(moduleAddress);
+            var dm6 = moduleInfo.get(DM6PendingEmissionDTCPacket.class);
+            var existingDTCs = toString(dm6 == null ? List.of() : dm6.getDtcs());
+
+            List<DM12MILOnEmissionDTCPacket> packets = globalPackets.stream()
+                    .filter(p -> p.getSourceAddress() == moduleAddress)
+                    .collect(Collectors.toList());
+            for (DM12MILOnEmissionDTCPacket packet : packets) {
+                var packetDTCs = toString(packet.getDtcs());
+                if (!packetDTCs.equals(existingDTCs)) {
+                    addFailure("6.4.2.2.b - " + moduleName + " reported DM12 DTC(s) different than DM6 pending DTC(s) in part 3");
+                    break;
+                }
+            }
+        }
+
         // 6.4.2.3.a. Warn if any ECU reports > 1 confirmed and active DTC.
-        // 6.4.2.3 b. Warn if more than one ECU reports a confirmed and active DTC.
+        globalPackets.stream()
+                .filter(p -> p.getDtcs().size() > 1)
+                .map(ParsedPacket::getSourceAddress)
+                .map(Lookup::getAddressName)
+                .forEach(moduleName -> addWarning("6.4.2.3.a - " + moduleName + " reported > 1 confirmed and active DTC"));
+
+        // 6.4.2.3.b. Warn if more than one ECU reports a confirmed and active DTC.
+        long modulesWithFaults = globalPackets.stream()
+                .filter(p -> !p.getDtcs().isEmpty())
+                .count();
+        if (modulesWithFaults > 1) {
+            addWarning("6.4.2.3.b - More than one ECU reported a confirmed and active DTC");
+        }
+
+        List<Integer> obdModuleAddresses = getDataRepository().getObdModuleAddresses();
+
         // 6.4.2.4.a. DS DM12 to each OBD ECU.
+        List<RequestResult<DM12MILOnEmissionDTCPacket>> dsResults = obdModuleAddresses.stream()
+                .map(address -> getDiagnosticMessageModule().requestDM12(getListener(), address))
+                .map(BusResult::requestResult)
+                .collect(Collectors.toList());
+
         // 6.4.2.5.a. Fail if any difference compared to data received from global request.
+        List<DM12MILOnEmissionDTCPacket> dsPackets = filterRequestResultPackets(dsResults);
+        compareRequestPackets(globalPackets, dsPackets, "6.4.2.5.a");
+
         // 6.4.2.5.b. Fail if NACK not received from OBD ECUs that did not respond to global query.
+        List<AcknowledgmentPacket> dsAcks = filterRequestResultAcks(dsResults);
+        checkForNACKs(globalPackets, dsAcks, obdModuleAddresses, "6.4.2.5.b");
+    }
+
+    private static String toString(List<DiagnosticTroubleCode> dtcs) {
+        return dtcs.stream()
+                .map(d -> d.getSuspectParameterNumber() + ":" + d.getFailureModeIndicator())
+                .sorted()
+                .collect(Collectors.joining(","));
     }
 
 }

--- a/src/org/etools/j1939_84/controllers/part04/Part04Step02Controller.java
+++ b/src/org/etools/j1939_84/controllers/part04/Part04Step02Controller.java
@@ -16,7 +16,6 @@ import org.etools.j1939_84.bus.j1939.Lookup;
 import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket;
 import org.etools.j1939_84.bus.j1939.packets.DM12MILOnEmissionDTCPacket;
 import org.etools.j1939_84.bus.j1939.packets.DM6PendingEmissionDTCPacket;
-import org.etools.j1939_84.bus.j1939.packets.DiagnosticTroubleCode;
 import org.etools.j1939_84.bus.j1939.packets.DiagnosticTroubleCodePacket;
 import org.etools.j1939_84.bus.j1939.packets.ParsedPacket;
 import org.etools.j1939_84.controllers.DataRepository;
@@ -174,13 +173,6 @@ public class Part04Step02Controller extends StepController {
         // 6.4.2.5.b. Fail if NACK not received from OBD ECUs that did not respond to global query.
         List<AcknowledgmentPacket> dsAcks = filterRequestResultAcks(dsResults);
         checkForNACKs(globalPackets, dsAcks, obdModuleAddresses, "6.4.2.5.b");
-    }
-
-    private static String toString(List<DiagnosticTroubleCode> dtcs) {
-        return dtcs.stream()
-                .map(d -> d.getSuspectParameterNumber() + ":" + d.getFailureModeIndicator())
-                .sorted()
-                .collect(Collectors.joining(","));
     }
 
 }


### PR DESCRIPTION
Part 4 Step 2 which is similar to Part 3 Step 2.  I did add 'getOutcomes()` to the `TestResultsListener` so we can see all the outcomes to help troubleshooting tests.