### PR TITLE
Fix #288 Implement Part 4 Step 3

### DIFF
--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step15ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step15ControllerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.concurrent.Executor;
 import org.etools.j1939_84.bus.Packet;
 import org.etools.j1939_84.bus.j1939.J1939;
@@ -21,7 +22,6 @@ import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.ResultsListener;
 import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
-import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DiagnosticMessageModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
@@ -120,7 +120,7 @@ public class Part01Step15ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(new RequestResult<>(false));
+        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of());
 
         runTest();
 
@@ -159,7 +159,7 @@ public class Part01Step15ControllerTest extends AbstractControllerTest {
         dataRepository.putObdModule(new OBDModuleInformation(3));
 
         when(diagnosticMessageModule.readDM1(any()))
-                .thenReturn(new RequestResult<>(false, packet1, packet2, packet3, packet4, packet5));
+                .thenReturn(List.of(packet1, packet2, packet3, packet4, packet5));
 
         runTest();
 
@@ -220,47 +220,7 @@ public class Part01Step15ControllerTest extends AbstractControllerTest {
                                         WARN,
                                         "6.1.15.3.b - Non-OBD Module Engine #1 (0) reported SPN conversion method (SPN 1706) equal to 1");
 
-        String expected = "" + NL;
-        expected += "10:15:30.0000 18FECA01 [14] 00 00 61 02 13 80 21 06 1F 00 EE 10 04 00" + NL;
-        expected += "DM1 from Engine #2 (1): MIL: alternate off, RSL: alternate off, AWL: alternate off, PL: alternate off"
-                + NL;
-        expected += "DTC 609:19 - Controller #2, Received Network Data In Error - 0 times" + NL;
-        expected += "DTC 1569:31 - Engine Protection Torque Derate, Condition Exists - 0 times" + NL;
-        expected += "DTC 4334:4 - AFT 1 DEF Doser 1 Absolute Pressure, Voltage Below Normal, Or Shorted To Low Source - 0 times"
-                + NL;
-        expected += "" + NL;
-        expected += "10:15:30.0000 18FECA17 [14] 00 00 61 02 13 80 21 06 1F 00 EE 10 04 00" + NL;
-        expected += "DM1 from Instrument Cluster #1 (23): MIL: alternate off, RSL: alternate off, AWL: alternate off, PL: alternate off"
-                + NL;
-        expected += "DTC 609:19 - Controller #2, Received Network Data In Error - 0 times" + NL;
-        expected += "DTC 1569:31 - Engine Protection Torque Derate, Condition Exists - 0 times" + NL;
-        expected += "DTC 4334:4 - AFT 1 DEF Doser 1 Absolute Pressure, Voltage Below Normal, Or Shorted To Low Source - 0 times"
-                + NL;
-        expected += "" + NL;
-        expected += "10:15:30.0000 18FECA03 [14] AA 55 61 02 13 80 21 06 1F 00 EE 10 04 00" + NL;
-        expected += "DM1 from Transmission #1 (3): MIL: other, RSL: other, AWL: other, PL: other" + NL;
-        expected += "DTC 609:19 - Controller #2, Received Network Data In Error - 0 times" + NL;
-        expected += "DTC 1569:31 - Engine Protection Torque Derate, Condition Exists - 0 times" + NL;
-        expected += "DTC 4334:4 - AFT 1 DEF Doser 1 Absolute Pressure, Voltage Below Normal, Or Shorted To Low Source - 0 times"
-                + NL;
-        expected += "" + NL;
-        expected += "10:15:30.0000 18FECA00 [14] 40 00 61 02 13 80 21 06 1F 00 EE 10 04 00" + NL;
-        expected += "DM1 from Engine #1 (0): MIL: slow flash, RSL: alternate off, AWL: alternate off, PL: alternate off"
-                + NL;
-        expected += "DTC 609:19 - Controller #2, Received Network Data In Error - 0 times" + NL;
-        expected += "DTC 1569:31 - Engine Protection Torque Derate, Condition Exists - 0 times" + NL;
-        expected += "DTC 4334:4 - AFT 1 DEF Doser 1 Absolute Pressure, Voltage Below Normal, Or Shorted To Low Source - 0 times"
-                + NL;
-        expected += "" + NL;
-        expected += "10:15:30.0000 18FECA00 [14] C0 C0 61 02 13 00 21 06 1F 00 EE 10 04 00" + NL;
-        expected += "DM1 from Engine #1 (0): MIL: not supported, RSL: alternate off, AWL: alternate off, PL: alternate off"
-                + NL;
-        expected += "DTC 609:19 - Controller #2, Received Network Data In Error - 0 times" + NL;
-        expected += "DTC 1569:31 - Engine Protection Torque Derate, Condition Exists - 0 times" + NL;
-        expected += "DTC 4334:4 - AFT 1 DEF Doser 1 Absolute Pressure, Voltage Below Normal, Or Shorted To Low Source - 0 times"
-                + NL;
-
-        assertEquals(expected, listener.getResults());
+        assertEquals("", listener.getResults());
     }
 
     /**
@@ -303,24 +263,13 @@ public class Part01Step15ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(new OBDModuleInformation(1));
 
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(new RequestResult<>(false, packet1, packet2));
+        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(packet1, packet2));
 
         runTest();
 
         verify(diagnosticMessageModule).setJ1939(j1939);
         verify(diagnosticMessageModule).readDM1(any());
 
-        String expected = "" + NL;
-        expected += "10:15:30.0000 18FECA01 [8] 00 FF 00 00 00 00 FF FF" + NL;
-        expected += "DM1 from Engine #2 (1): MIL: off, RSL: off, AWL: off, PL: off, No DTCs" + NL;
-        expected += "" + NL;
-        expected += "10:15:30.0000 18FECA17 [14] 00 FF 61 02 13 00 21 06 1F 00 EE 10 04 00" + NL;
-        expected += "DM1 from Instrument Cluster #1 (23): MIL: off, RSL: off, AWL: off, PL: off" + NL;
-        expected += "DTC 609:19 - Controller #2, Received Network Data In Error - 0 times" + NL;
-        expected += "DTC 1569:31 - Engine Protection Torque Derate, Condition Exists - 0 times" + NL;
-        expected += "DTC 4334:4 - AFT 1 DEF Doser 1 Absolute Pressure, Voltage Below Normal, Or Shorted To Low Source - 0 times"
-                + NL;
-
-        assertEquals(expected, listener.getResults());
+        assertEquals("", listener.getResults());
     }
 }

--- a/src-test/org/etools/j1939_84/controllers/part03/Part03Step06ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part03/Part03Step06ControllerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.concurrent.Executor;
 import org.etools.j1939_84.bus.j1939.J1939;
 import org.etools.j1939_84.bus.j1939.packets.DM1ActiveDTCsPacket;
@@ -23,7 +24,6 @@ import org.etools.j1939_84.controllers.ResultsListener;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
-import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
 import org.etools.j1939_84.modules.DiagnosticMessageModule;
@@ -138,7 +138,7 @@ public class Part03Step06ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(new RequestResult<>(false, dm1_0, dm1_21));
+        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1_0, dm1_21));
 
         runTest();
 
@@ -156,7 +156,7 @@ public class Part03Step06ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(new RequestResult<>(false, dm1_0, dm1_21));
+        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1_0, dm1_21));
 
         runTest();
 
@@ -169,7 +169,7 @@ public class Part03Step06ControllerTest extends AbstractControllerTest {
 
     @Test
     public void testNoMessages() {
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(new RequestResult<>(false));
+        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of());
 
         runTest();
 
@@ -186,7 +186,7 @@ public class Part03Step06ControllerTest extends AbstractControllerTest {
     public void testFailureForNoOBDSupport() {
         var dm1 = DM1ActiveDTCsPacket.create(0, OFF, OFF, OFF, OFF);
 
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(new RequestResult<>(false, dm1));
+        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1));
 
         runTest();
 
@@ -207,7 +207,7 @@ public class Part03Step06ControllerTest extends AbstractControllerTest {
 
         dataRepository.putObdModule(new OBDModuleInformation(0));
 
-        when(diagnosticMessageModule.readDM1(any())).thenReturn(new RequestResult<>(false, dm1_0, dm1_21));
+        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1_0, dm1_21));
 
         runTest();
 

--- a/src-test/org/etools/j1939_84/controllers/part04/Part04Step03ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part04/Part04Step03ControllerTest.java
@@ -3,15 +3,27 @@
  */
 package org.etools.j1939_84.controllers.part04;
 
+import static org.etools.j1939_84.bus.j1939.packets.LampStatus.OFF;
+import static org.etools.j1939_84.bus.j1939.packets.LampStatus.ON;
+import static org.etools.j1939_84.model.Outcome.FAIL;
+import static org.etools.j1939_84.model.Outcome.WARN;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.concurrent.Executor;
 import org.etools.j1939_84.bus.j1939.J1939;
+import org.etools.j1939_84.bus.j1939.packets.DM12MILOnEmissionDTCPacket;
+import org.etools.j1939_84.bus.j1939.packets.DM1ActiveDTCsPacket;
+import org.etools.j1939_84.bus.j1939.packets.DiagnosticTroubleCode;
 import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.ResultsListener;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.controllers.TestResultsListener;
+import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
 import org.etools.j1939_84.modules.DiagnosticMessageModule;
@@ -118,11 +130,160 @@ public class Part04Step03ControllerTest extends AbstractControllerTest {
 
     @Test
     public void testHappyPathNoFailures() {
+        var dtc = DiagnosticTroubleCode.create(123, 12, 1, 1);
+
+        OBDModuleInformation moduleInformation = new OBDModuleInformation(0);
+        moduleInformation.set(DM12MILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc));
+        dataRepository.putObdModule(moduleInformation);
+
+        var dm1 = DM1ActiveDTCsPacket.create(0, ON, OFF, OFF, OFF, dtc);
+        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1));
 
         runTest();
 
+        verify(diagnosticMessageModule).readDM1(any());
+
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
+        assertEquals(0, listener.getOutcomes().size());
+    }
+
+    @Test
+    public void testNoActiveDTCFailure() {
+        var dm1 = DM1ActiveDTCsPacket.create(0, OFF, OFF, OFF, OFF);
+        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1));
+
+        runTest();
+
+        verify(diagnosticMessageModule).readDM1(any());
+
+        assertEquals("", listener.getMessages());
+        assertEquals("", listener.getResults());
+        assertEquals(1, listener.getOutcomes().size());
+
+        verify(mockListener).addOutcome(PART_NUMBER,
+                                        STEP_NUMBER,
+                                        FAIL,
+                                        "6.4.3.2.a - No ECU reported an active DTC and MIL on");
+    }
+
+    @Test
+    public void testDifferentDTCsFailure() {
+        //Module 0 Different DTCs
+        var dtc1 = DiagnosticTroubleCode.create(123, 12, 1, 1);
+        OBDModuleInformation moduleInfo0 = new OBDModuleInformation(0);
+        moduleInfo0.set(DM12MILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc1));
+        dataRepository.putObdModule(moduleInfo0);
+        var dtc2 = DiagnosticTroubleCode.create(456, 9, 1, 1);
+        var dm1_0 = DM1ActiveDTCsPacket.create(0, ON, OFF, OFF, OFF, dtc2);
+
+        //Module 1 No active DTC in DM1
+        OBDModuleInformation moduleInfo1 = new OBDModuleInformation(1);
+        moduleInfo1.set(DM12MILOnEmissionDTCPacket.create(1, ON, OFF, OFF, OFF, dtc1));
+        dataRepository.putObdModule(moduleInfo1);
+        var dm1_1 = DM1ActiveDTCsPacket.create(1, OFF, OFF, OFF, OFF);
+
+        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1_0, dm1_1));
+
+        runTest();
+
+        verify(diagnosticMessageModule).readDM1(any());
+
+        assertEquals("", listener.getMessages());
+        assertEquals("", listener.getResults());
+        assertEquals(3, listener.getOutcomes().size());
+
+        verify(mockListener).addOutcome(PART_NUMBER,
+                                        STEP_NUMBER,
+                                        FAIL,
+                                        "6.4.3.2.b - Engine #1 (0) did not include its DM12 DTCs in the list of active DTCs");
+
+        verify(mockListener).addOutcome(PART_NUMBER,
+                                        STEP_NUMBER,
+                                        FAIL,
+                                        "6.4.3.2.b - Engine #2 (1) did not include its DM12 DTCs in the list of active DTCs");
+
+        verify(mockListener).addOutcome(PART_NUMBER,
+                                        STEP_NUMBER,
+                                        FAIL,
+                                        "6.4.3.2.c - Engine #2 (1) reported fewer active DTCs in its DM1 response than its DM12 response");
+    }
+
+    @Test
+    public void testNonOBDActiveDTCWarning() {
+        var dtc = DiagnosticTroubleCode.create(123, 12, 1, 1);
+
+        var dm1 = DM1ActiveDTCsPacket.create(0, ON, OFF, OFF, OFF, dtc);
+        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1));
+
+        runTest();
+
+        verify(diagnosticMessageModule).readDM1(any());
+
+        assertEquals("", listener.getMessages());
+        assertEquals("", listener.getResults());
+        assertEquals(1, listener.getOutcomes().size());
+
+        verify(mockListener).addOutcome(PART_NUMBER,
+                                        STEP_NUMBER,
+                                        WARN,
+                                        "6.4.3.2.d - Non-OBD ECU Engine #1 (0) reported an active DTC");
+    }
+
+    @Test
+    public void testMultipleActiveDTCWarningFromOneModule() {
+        var dtc1 = DiagnosticTroubleCode.create(123, 12, 1, 1);
+        var dtc2 = DiagnosticTroubleCode.create(456, 9, 1, 1);
+
+        OBDModuleInformation moduleInfo0 = new OBDModuleInformation(0);
+        moduleInfo0.set(DM12MILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc1, dtc2));
+        dataRepository.putObdModule(moduleInfo0);
+
+        var dm1 = DM1ActiveDTCsPacket.create(0, ON, OFF, OFF, OFF, dtc1, dtc2);
+        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1));
+
+        runTest();
+
+        verify(diagnosticMessageModule).readDM1(any());
+
+        assertEquals("", listener.getMessages());
+        assertEquals("", listener.getResults());
+        assertEquals(1, listener.getOutcomes().size());
+
+        verify(mockListener).addOutcome(PART_NUMBER,
+                                        STEP_NUMBER,
+                                        WARN,
+                                        "6.4.3.2.e - More than 1 active DTC is reported by the vehicle");
+    }
+
+    @Test
+    public void testMultipleActiveDTCWarningFromMultipleModules() {
+        var dtc0 = DiagnosticTroubleCode.create(123, 12, 1, 1);
+        var dm1_0 = DM1ActiveDTCsPacket.create(0, ON, OFF, OFF, OFF, dtc0);
+        OBDModuleInformation moduleInfo0 = new OBDModuleInformation(0);
+        moduleInfo0.set(DM12MILOnEmissionDTCPacket.create(0, ON, OFF, OFF, OFF, dtc0));
+        dataRepository.putObdModule(moduleInfo0);
+
+        var dtc1 = DiagnosticTroubleCode.create(456, 9, 1, 1);
+        var dm1_1 = DM1ActiveDTCsPacket.create(1, ON, OFF, OFF, OFF, dtc1);
+        OBDModuleInformation moduleInfo1 = new OBDModuleInformation(1);
+        moduleInfo1.set(DM12MILOnEmissionDTCPacket.create(1, ON, OFF, OFF, OFF, dtc1));
+        dataRepository.putObdModule(moduleInfo1);
+
+        when(diagnosticMessageModule.readDM1(any())).thenReturn(List.of(dm1_0, dm1_1));
+
+        runTest();
+
+        verify(diagnosticMessageModule).readDM1(any());
+
+        assertEquals("", listener.getMessages());
+        assertEquals("", listener.getResults());
+        assertEquals(1, listener.getOutcomes().size());
+
+        verify(mockListener).addOutcome(PART_NUMBER,
+                                        STEP_NUMBER,
+                                        WARN,
+                                        "6.4.3.2.e - More than 1 active DTC is reported by the vehicle");
     }
 
 }

--- a/src-test/org/etools/j1939_84/modules/DiagnosticMessageModuleTest.java
+++ b/src-test/org/etools/j1939_84/modules/DiagnosticMessageModuleTest.java
@@ -98,10 +98,16 @@ public class DiagnosticMessageModuleTest {
 
         TestResultsListener listener = new TestResultsListener();
 
-        RequestResult<DM1ActiveDTCsPacket> expectedResult = new RequestResult<>(false, packet);
-        assertEquals(expectedResult, instance.readDM1(listener));
+        assertEquals(List.of(packet), instance.readDM1(listener));
 
-        String expected = "10:15:30.0000 Reading the bus for published DM1 messages" + NL;
+        String expected = "";
+        expected += "10:15:30.0000 Reading the bus for published DM1 messages" + NL;
+        expected += "" + NL;
+        expected += "10:15:30.0000 18FECA00 [14] 11 01 61 02 13 00 21 06 1F 00 EE 10 04 00" + NL;
+        expected += "DM1 from Engine #1 (0): MIL: alternate off, RSL: slow flash, AWL: alternate off, PL: fast flash" + NL;
+        expected += "DTC 609:19 - Controller #2, Received Network Data In Error - 0 times" + NL;
+        expected += "DTC 1569:31 - Engine Protection Torque Derate, Condition Exists - 0 times" + NL;
+        expected += "DTC 4334:4 - AFT 1 DEF Doser 1 Absolute Pressure, Voltage Below Normal, Or Shorted To Low Source - 0 times" + NL;
 
         assertEquals(expected, listener.getResults());
         verify(j1939).read(DM1ActiveDTCsPacket.class, 3, TimeUnit.SECONDS);
@@ -114,10 +120,10 @@ public class DiagnosticMessageModuleTest {
 
         TestResultsListener listener = new TestResultsListener();
 
-        RequestResult<DM1ActiveDTCsPacket> expectedResult = new RequestResult<>(false);
-        assertEquals(expectedResult, instance.readDM1(listener));
+        assertEquals(List.of(), instance.readDM1(listener));
 
         String expected = "10:15:30.0000 Reading the bus for published DM1 messages" + NL;
+
         assertEquals(expected, listener.getResults());
         verify(j1939).read(DM1ActiveDTCsPacket.class, 3, TimeUnit.SECONDS);
         verify(j1939).read(anyLong(), any());
@@ -139,12 +145,21 @@ public class DiagnosticMessageModuleTest {
 
         TestResultsListener listener = new TestResultsListener();
 
-        RequestResult<DM1ActiveDTCsPacket> expectedResult = new RequestResult<>(false,
-                                                                                List.of(packet1, packet2),
-                                                                                List.of());
-        assertEquals(expectedResult, instance.readDM1(listener));
+        assertEquals(List.of(packet1, packet2), instance.readDM1(listener));
 
         String expected = "10:15:30.0000 Reading the bus for published DM1 messages" + NL;
+        expected += "" + NL;
+        expected += "10:15:30.0000 18FECA00 [14] 11 01 61 02 13 00 21 06 1F 00 EE 10 04 00" + NL;
+        expected += "DM1 from Engine #1 (0): MIL: alternate off, RSL: slow flash, AWL: alternate off, PL: fast flash" + NL;
+        expected += "DTC 609:19 - Controller #2, Received Network Data In Error - 0 times" + NL;
+        expected += "DTC 1569:31 - Engine Protection Torque Derate, Condition Exists - 0 times" + NL;
+        expected += "DTC 4334:4 - AFT 1 DEF Doser 1 Absolute Pressure, Voltage Below Normal, Or Shorted To Low Source - 0 times" + NL;
+        expected += "" + NL;
+        expected += "10:15:30.0000 18FECA01 [14] 11 01 61 02 13 00 21 06 1F 00 EE 10 04 00" + NL;
+        expected += "DM1 from Engine #2 (1): MIL: alternate off, RSL: slow flash, AWL: alternate off, PL: fast flash" + NL;
+        expected += "DTC 609:19 - Controller #2, Received Network Data In Error - 0 times" + NL;
+        expected += "DTC 1569:31 - Engine Protection Torque Derate, Condition Exists - 0 times" + NL;
+        expected += "DTC 4334:4 - AFT 1 DEF Doser 1 Absolute Pressure, Voltage Below Normal, Or Shorted To Low Source - 0 times" + NL;
         assertEquals(expected, listener.getResults());
         verify(j1939).read(DM1ActiveDTCsPacket.class, 3, TimeUnit.SECONDS);
         verify(j1939).read(anyLong(), any());

--- a/src/org/etools/j1939_84/controllers/part01/Part01Step15Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step15Controller.java
@@ -3,20 +3,17 @@
  */
 package org.etools.j1939_84.controllers.part01;
 
-import static org.etools.j1939_84.J1939_84.NL;
 import static org.etools.j1939_84.bus.j1939.packets.LampStatus.NOT_SUPPORTED;
 import static org.etools.j1939_84.bus.j1939.packets.LampStatus.OFF;
 
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
-import org.etools.j1939_84.bus.Packet;
 import org.etools.j1939_84.bus.j1939.Lookup;
 import org.etools.j1939_84.bus.j1939.packets.DM1ActiveDTCsPacket;
 import org.etools.j1939_84.bus.j1939.packets.LampStatus;
 import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
-import org.etools.j1939_84.model.RequestResult;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
 import org.etools.j1939_84.modules.DiagnosticMessageModule;
@@ -67,8 +64,7 @@ public class Part01Step15Controller extends StepController {
     protected void run() throws Throwable {
 
         // 6.1.15.1.a. Gather broadcast DM1 data from all ECUs (PGN 65226)
-        RequestResult<DM1ActiveDTCsPacket> results = getDiagnosticMessageModule().readDM1(getListener());
-        List<DM1ActiveDTCsPacket> packets = results.getPackets();
+        List<DM1ActiveDTCsPacket> packets = getDiagnosticMessageModule().readDM1(getListener());
 
         boolean foundObdPacket = false;
 
@@ -77,10 +73,6 @@ public class Part01Step15Controller extends StepController {
             boolean isObdModule = getDataRepository().isObdModule(sourceAddress);
             String moduleName = Lookup.getAddressName(sourceAddress);
             foundObdPacket |= isObdModule;
-
-            Packet dm1Packet = dm1.getPacket();
-            getListener().onResult(NL + getDateTimeModule().format(dm1Packet.getTimestamp()) + " " + dm1Packet);
-            getListener().onResult(dm1.toString());
 
             // 6.1.15.2.a. Fail if any OBD ECU reports an active DTC.
             if (isObdModule && !dm1.getDtcs().isEmpty()) {

--- a/src/org/etools/j1939_84/controllers/part03/Part03Step06Controller.java
+++ b/src/org/etools/j1939_84/controllers/part03/Part03Step06Controller.java
@@ -62,7 +62,7 @@ public class Part03Step06Controller extends StepController {
     @Override
     protected void run() throws Throwable {
         // 6.3.6.1.a Receive DM1 broadcast info (PGN 65226 (SPNs 1213-1215, 1706, and 3038)).
-        List<DM1ActiveDTCsPacket> packets = getDiagnosticMessageModule().readDM1(getListener()).getPackets();
+        List<DM1ActiveDTCsPacket> packets = getDiagnosticMessageModule().readDM1(getListener());
 
         // 6.3.6.2.a Fail if no OBD ECU supports DM1.
         boolean noObdDM1s = packets.stream().noneMatch(p -> getDataRepository().isObdModule(p.getSourceAddress()));

--- a/src/org/etools/j1939_84/controllers/part04/Part04Step03Controller.java
+++ b/src/org/etools/j1939_84/controllers/part04/Part04Step03Controller.java
@@ -3,10 +3,22 @@
  */
 package org.etools.j1939_84.controllers.part04;
 
+import static org.etools.j1939_84.bus.j1939.packets.LampStatus.ON;
+
+import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+import org.etools.j1939_84.bus.j1939.Lookup;
+import org.etools.j1939_84.bus.j1939.packets.DM12MILOnEmissionDTCPacket;
+import org.etools.j1939_84.bus.j1939.packets.DM1ActiveDTCsPacket;
+import org.etools.j1939_84.bus.j1939.packets.DiagnosticTroubleCode;
+import org.etools.j1939_84.bus.j1939.packets.DiagnosticTroubleCodePacket;
+import org.etools.j1939_84.bus.j1939.packets.ParsedPacket;
 import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
+import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.modules.BannerModule;
 import org.etools.j1939_84.modules.DateTimeModule;
 import org.etools.j1939_84.modules.DiagnosticMessageModule;
@@ -53,11 +65,73 @@ public class Part04Step03Controller extends StepController {
     @Override
     protected void run() throws Throwable {
         // 6.4.3.1.a Receive broadcast data ([PGN 65226 (SPNs 1213-1215, 3038, 1706)]).
+        List<DM1ActiveDTCsPacket> packets = getDiagnosticMessageModule().readDM1(getListener());
+
         // 6.4.3.2.a Fail if no ECU reports an active DTC and MIL on.
+        boolean noReports = packets.stream()
+                .noneMatch(p -> !p.getDtcs().isEmpty() || p.getMalfunctionIndicatorLampStatus() == ON);
+        if (noReports) {
+            addFailure("6.4.3.2.a - No ECU reported an active DTC and MIL on");
+        }
+
         // 6.4.3.2.b Fail if any OBD ECU report does not include its DM12 DTCs in the list of active DTCs.
+        for (OBDModuleInformation moduleInfo : getDataRepository().getObdModules()) {
+            int moduleAddress = moduleInfo.getSourceAddress();
+            String moduleName = Lookup.getAddressName(moduleAddress);
+            DM12MILOnEmissionDTCPacket dm12 = moduleInfo.get(DM12MILOnEmissionDTCPacket.class);
+            List<DiagnosticTroubleCode> existingDTCs = dm12 == null ? List.of() : dm12.getDtcs();
+
+            List<DM1ActiveDTCsPacket> modulePackets = packets.stream()
+                    .filter(p -> p.getSourceAddress() == moduleAddress)
+                    .collect(Collectors.toList());
+            for (DM1ActiveDTCsPacket packet : modulePackets) {
+                boolean failure = false;
+                var packetDTCs = toString(packet.getDtcs());
+                for (DiagnosticTroubleCode dtc : existingDTCs) {
+                    String key = dtc.getSuspectParameterNumber() + ":" + dtc.getFailureModeIndicator();
+                    if (!packetDTCs.contains(key)) {
+                        failure = true;
+                        addFailure("6.4.3.2.b - " + moduleName + " did not include its DM12 DTCs in the list of active DTCs");
+                        break;
+                    }
+                }
+                if (failure) {
+                    break;
+                }
+            }
+        }
+
         // 6.4.3.2.c Fail if any OBD ECU reports fewer active DTCs in its DM1 response than its DM12 response.
+        for (OBDModuleInformation moduleInfo : getDataRepository().getObdModules()) {
+            int moduleAddress = moduleInfo.getSourceAddress();
+            String moduleName = Lookup.getAddressName(moduleAddress);
+            DM12MILOnEmissionDTCPacket dm12 = moduleInfo.get(DM12MILOnEmissionDTCPacket.class);
+            List<DiagnosticTroubleCode> existingDTCs = dm12 == null ? List.of() : dm12.getDtcs();
+
+            List<DM1ActiveDTCsPacket> modulePackets = packets.stream()
+                    .filter(p -> p.getSourceAddress() == moduleAddress)
+                    .collect(Collectors.toList());
+            for (DM1ActiveDTCsPacket packet : modulePackets) {
+                if (packet.getDtcs().size() < existingDTCs.size()) {
+                    addFailure("6.4.3.2.c - " + moduleName + " reported fewer active DTCs in its DM1 response than its DM12 response");
+                    break;
+                }
+            }
+        }
+
         // 6.4.3.2.d Warn if any non-OBD ECU reports an Active DTC.
+        packets.stream()
+                .filter(p -> !getDataRepository().isObdModule(p.getSourceAddress()))
+                .filter(p -> !p.getDtcs().isEmpty())
+                .map(ParsedPacket::getModuleName)
+                .forEach(moduleName -> addWarning("6.4.3.2.d - Non-OBD ECU " + moduleName + " reported an active DTC"));
+
         // 6.4.3.2.e Warn if more than 1 active DTC is reported by the vehicle.
+        long dtcCount = packets.stream().map(DiagnosticTroubleCodePacket::getDtcs).mapToLong(Collection::size).sum();
+        if (dtcCount > 1) {
+            addWarning("6.4.3.2.e - More than 1 active DTC is reported by the vehicle");
+        }
+
     }
 
 }

--- a/src/org/etools/j1939_84/controllers/part04/Part04Step03Controller.java
+++ b/src/org/etools/j1939_84/controllers/part04/Part04Step03Controller.java
@@ -74,6 +74,15 @@ public class Part04Step03Controller extends StepController {
             addFailure("6.4.3.2.a - No ECU reported an active DTC and MIL on");
         }
 
+        //Save DM1 for use later
+        packets.forEach(p -> {
+            OBDModuleInformation moduleInfo = getDataRepository().getObdModule(p.getSourceAddress());
+            if (moduleInfo != null) {
+                moduleInfo.set(p);
+                getDataRepository().putObdModule(moduleInfo);
+            }
+        });
+
         // 6.4.3.2.b Fail if any OBD ECU report does not include its DM12 DTCs in the list of active DTCs.
         for (OBDModuleInformation moduleInfo : getDataRepository().getObdModules()) {
             int moduleAddress = moduleInfo.getSourceAddress();

--- a/src/org/etools/j1939_84/modules/DiagnosticMessageModule.java
+++ b/src/org/etools/j1939_84/modules/DiagnosticMessageModule.java
@@ -3,6 +3,7 @@
  */
 package org.etools.j1939_84.modules;
 
+import static org.etools.j1939_84.J1939_84.NL;
 import static org.etools.j1939_84.bus.j1939.J1939.GLOBAL_ADDR;
 
 import java.util.ArrayList;
@@ -78,7 +79,7 @@ public class DiagnosticMessageModule extends FunctionalModule {
         return getCompositeSystems(systems, isDM5);
     }
 
-    public RequestResult<DM1ActiveDTCsPacket> readDM1(ResultsListener listener) {
+    public List<DM1ActiveDTCsPacket> readDM1(ResultsListener listener) {
         String title = " Reading the bus for published DM1 messages";
         listener.onResult(getTime() + title);
 
@@ -92,7 +93,9 @@ public class DiagnosticMessageModule extends FunctionalModule {
                 .sorted(Comparator.comparing(o -> o.getPacket().getTimestamp()))
                 .collect(Collectors.toList());
 
-        return new RequestResult<>(false, packets, List.of());
+        packets.forEach(dm1 -> listener.onResult(NL + dm1.getPacket().toTimeString() + NL + dm1.toString()));
+
+        return packets;
     }
 
     public RequestResult<DM2PreviouslyActiveDTC> requestDM2(ResultsListener listener) {

--- a/src/org/etools/j1939_84/ui/UserInterfacePresenter.java
+++ b/src/org/etools/j1939_84/ui/UserInterfacePresenter.java
@@ -27,6 +27,7 @@ import org.etools.j1939_84.bus.j1939.J1939TP;
 import org.etools.j1939_84.controllers.OverallController;
 import org.etools.j1939_84.controllers.QuestionListener;
 import org.etools.j1939_84.controllers.ResultsListener;
+import org.etools.j1939_84.model.ActionOutcome;
 import org.etools.j1939_84.model.Outcome;
 import org.etools.j1939_84.model.PartResult;
 import org.etools.j1939_84.model.StepResult;
@@ -224,6 +225,7 @@ public class UserInterfacePresenter implements UserInterfaceContract.Presenter {
         return new ResultsListener() {
             @Override
             public void addOutcome(int partNumber, int stepNumber, Outcome outcome, String message) {
+                onResult(new ActionOutcome(outcome, message).toString());
             }
 
             @Override


### PR DESCRIPTION
I found the `DiagnosticMessageModule` was not logging the packets received when we called `readDM1`.  So now it does and the controllers don't need to write the packets to the log.

And implemented Part 4 Step 3