### PR TITLE
Fix #593 Part 1 Step 10 doesn't wait before checking the failure conditions

### DIFF
--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step10ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step10ControllerTest.java
@@ -134,7 +134,7 @@ public class Part01Step10ControllerTest extends AbstractControllerTest {
         verify(diagnosticMessageModule).setJ1939(j1939);
         verify(diagnosticMessageModule).requestDM11(any());
 
-        verify(mockListener).addOutcome(1, 10, FAIL, "6.1.10.3.a - The request for DM11 was NACK'ed by Engine #2 (1)");
+        verify(mockListener).addOutcome(1, 10, FAIL, "6.1.10.2.a - The request for DM11 was NACK'ed by Engine #2 (1)");
         verify(mockListener).addOutcome(1, 10, WARN, "6.1.10.3.a - The request for DM11 was ACK'ed by Engine #1 (0)");
 
         verify(dataRepository).isObdModule(0);
@@ -186,11 +186,11 @@ public class Part01Step10ControllerTest extends AbstractControllerTest {
         verify(dataRepository).isObdModule(0);
 
         String expectedMessages = "";
-        expectedMessages += "Waiting for 5 seconds" + NL;
-        expectedMessages += "Waiting for 4 seconds" + NL;
-        expectedMessages += "Waiting for 3 seconds" + NL;
-        expectedMessages += "Waiting for 2 seconds" + NL;
-        expectedMessages += "Waiting for 1 seconds";
+        expectedMessages += "Step 1.10.1.c. Waiting for 5 seconds" + NL;
+        expectedMessages += "Step 1.10.1.c. Waiting for 4 seconds" + NL;
+        expectedMessages += "Step 1.10.1.c. Waiting for 3 seconds" + NL;
+        expectedMessages += "Step 1.10.1.c. Waiting for 2 seconds" + NL;
+        expectedMessages += "Step 1.10.1.c. Waiting for 1 seconds";
         assertEquals(expectedMessages, listener.getMessages());
         assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());

--- a/src/org/etools/j1939_84/controllers/part01/Part01Step10Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step10Controller.java
@@ -3,19 +3,20 @@
  */
 package org.etools.j1939_84.controllers.part01;
 
+import static org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket.Response.ACK;
+import static org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket.Response.NACK;
+
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
-import org.etools.j1939_84.bus.j1939.Lookup;
 import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket;
-import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket.Response;
 import org.etools.j1939_84.bus.j1939.packets.ParsedPacket;
 import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
-import org.etools.j1939_84.modules.DiagnosticMessageModule;
 import org.etools.j1939_84.modules.DateTimeModule;
+import org.etools.j1939_84.modules.DiagnosticMessageModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 
@@ -64,27 +65,25 @@ public class Part01Step10Controller extends StepController {
 
         // 6.1.10.1.a. Global DM11 (send Request (PGN 59904) for PGN 65235).
         // 6.1.10.1.b. Record all ACK/NACK/BUSY/Access Denied responses (for PGN 65235) in the log.
-        List<AcknowledgmentPacket> globalDM11Packets = getDiagnosticMessageModule().requestDM11(getListener())
+        List<AcknowledgmentPacket> packets = getDiagnosticMessageModule().requestDM11(getListener())
                 .stream()
                 .filter(p -> getDataRepository().isObdModule(p.getSourceAddress()))
                 .collect(Collectors.toList());
 
+        // 6.1.10.1.c. Allow 5 s to elapse before proceeding with test step 6.1.10.2.
+        pause("Step 1.10.1.c. Waiting for %1$d seconds", 5L);
+
         // 6.1.10.2.a. Fail if NACK received from any HD OBD ECU
-        globalDM11Packets.stream()
-                .filter(packet -> packet.getResponse() == Response.NACK)
-                .map(ParsedPacket::getSourceAddress)
-                .map(Lookup::getAddressName)
-                .forEach(moduleName -> addFailure("6.1.10.3.a - The request for DM11 was NACK'ed by " + moduleName));
+        packets.stream()
+                .filter(p -> p.getResponse() == NACK)
+                .map(ParsedPacket::getModuleName)
+                .forEach(moduleName -> addFailure("6.1.10.2.a - The request for DM11 was NACK'ed by " + moduleName));
 
         // 6.1.10.3.a. Warn if ACK received from any HD OBD ECU.
-        globalDM11Packets.stream()
-                .filter(packet -> packet.getResponse() == Response.ACK)
-                .map(ParsedPacket::getSourceAddress)
-                .map(Lookup::getAddressName)
+        packets.stream()
+                .filter(p -> p.getResponse() == ACK)
+                .map(ParsedPacket::getModuleName)
                 .forEach(moduleName -> addWarning("6.1.10.3.a - The request for DM11 was ACK'ed by " + moduleName));
-
-        // 6.1.10.1.c. Allow 5 s to elapse before proceeding with test step 6.1.10.2.
-        pause("Waiting for %1$d seconds", 5L);
 
     }
 

--- a/src/org/etools/j1939_84/modules/DiagnosticMessageModule.java
+++ b/src/org/etools/j1939_84/modules/DiagnosticMessageModule.java
@@ -18,7 +18,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.etools.j1939_84.bus.j1939.BusResult;
 import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket;
-import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket.Response;
 import org.etools.j1939_84.bus.j1939.packets.CompositeMonitoredSystem;
 import org.etools.j1939_84.bus.j1939.packets.CompositeSystem;
 import org.etools.j1939_84.bus.j1939.packets.DM12MILOnEmissionDTCPacket;
@@ -123,17 +122,7 @@ public class DiagnosticMessageModule extends FunctionalModule {
     }
 
     public List<AcknowledgmentPacket> requestDM11(ResultsListener listener) {
-        listener.onResult(getTime() + " Clearing Diagnostic Trouble Codes");
-
-        List<AcknowledgmentPacket> responses = getJ1939().requestDM11(listener);
-
-        if (!responses.isEmpty() && responses.stream().allMatch(t -> t.getResponse() == Response.ACK)) {
-            listener.onResult("Diagnostic Trouble Codes were successfully cleared.");
-        } else {
-            listener.onResult("ERROR: Clearing Diagnostic Trouble Codes failed.");
-        }
-
-        return responses;
+        return getJ1939().requestDM11(listener);
     }
 
     public RequestResult<DM12MILOnEmissionDTCPacket> requestDM12(ResultsListener listener) {


### PR DESCRIPTION
The waiting was happening, but it happened after writing the failures/warnings, which doesn't really matter because the packets have already been read.  I also updated the progress bar to indicate which step is doing the waiting.