### PR TITLE
Implement Part 4 Step 13

### DIFF
--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step10ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step10ControllerTest.java
@@ -4,6 +4,9 @@
 package org.etools.j1939_84.controllers.part01;
 
 import static org.etools.j1939_84.J1939_84.NL;
+import static org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket.Response.ACK;
+import static org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket.Response.BUSY;
+import static org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket.Response.NACK;
 import static org.etools.j1939_84.model.Outcome.FAIL;
 import static org.etools.j1939_84.model.Outcome.WARN;
 import static org.junit.Assert.assertEquals;
@@ -110,16 +113,9 @@ public class Part01Step10ControllerTest extends AbstractControllerTest {
 
     @Test
     public void testError() {
-        AcknowledgmentPacket ackPacket = mock(AcknowledgmentPacket.class);
-        when(ackPacket.getResponse()).thenReturn(Response.ACK);
-        when(ackPacket.getSourceAddress()).thenReturn(0);
-
-        AcknowledgmentPacket ackPacket2 = mock(AcknowledgmentPacket.class);
-        when(ackPacket2.getSourceAddress()).thenReturn(2);
-
-        AcknowledgmentPacket nackPacket = mock(AcknowledgmentPacket.class);
-        when(nackPacket.getResponse()).thenReturn(Response.NACK);
-        when(nackPacket.getSourceAddress()).thenReturn(1);
+        AcknowledgmentPacket ackPacket = AcknowledgmentPacket.create(0, ACK);
+        AcknowledgmentPacket nackPacket = AcknowledgmentPacket.create(1, NACK);
+        AcknowledgmentPacket ackPacket2 = AcknowledgmentPacket.create(2, BUSY);
 
         List<AcknowledgmentPacket> acknowledgmentPackets = List.of(ackPacket, nackPacket, ackPacket2);
 
@@ -144,11 +140,11 @@ public class Part01Step10ControllerTest extends AbstractControllerTest {
         assertEquals("", listener.getResults());
 
         String expectedMessages = "";
-        expectedMessages += "Waiting for 5 seconds" + NL;
-        expectedMessages += "Waiting for 4 seconds" + NL;
-        expectedMessages += "Waiting for 3 seconds" + NL;
-        expectedMessages += "Waiting for 2 seconds" + NL;
-        expectedMessages += "Waiting for 1 seconds";
+        expectedMessages += "Step 1.10.1.c. Waiting for 5 seconds" + NL;
+        expectedMessages += "Step 1.10.1.c. Waiting for 4 seconds" + NL;
+        expectedMessages += "Step 1.10.1.c. Waiting for 3 seconds" + NL;
+        expectedMessages += "Step 1.10.1.c. Waiting for 2 seconds" + NL;
+        expectedMessages += "Step 1.10.1.c. Waiting for 1 seconds";
         assertEquals(expectedMessages, listener.getMessages());
         assertEquals("", listener.getMilestones());
     }

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step27ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step27ControllerTest.java
@@ -167,7 +167,7 @@ public class Part01Step27ControllerTest extends AbstractControllerTest {
         expectedMessages.append("Part 1, Step 27 b.iii - Allowing engine to idle one minute");
         int minuteCounter = 60;
         for (int i = minuteCounter; i > 0; i--) {
-            expectedMessages.append(NL).append("Allowing engine to idle for ").append(i).append(" seconds");
+            expectedMessages.append(NL).append("Step 1.27.b.iii Allowing engine to idle for ").append(i).append(" seconds");
         }
         expectedMessages.append(NL).append("User cancelled testing at Part 1 Step 27");
         assertEquals(expectedMessages.toString(), listener.getMessages());
@@ -246,7 +246,7 @@ public class Part01Step27ControllerTest extends AbstractControllerTest {
         expectedMessages.append("Part 1, Step 27 b.iii - Allowing engine to idle one minute");
         int minuteCounter = 60;
         for (int i = minuteCounter; i > 0; i--) {
-            expectedMessages.append(NL).append("Allowing engine to idle for ").append(i).append(" seconds");
+            expectedMessages.append(NL).append("Step 1.27.b.iii Allowing engine to idle for ").append(i).append(" seconds");
         }
         assertEquals(expectedMessages.toString(), listener.getMessages());
 
@@ -297,7 +297,7 @@ public class Part01Step27ControllerTest extends AbstractControllerTest {
         expectedMessages.append("Part 1, Step 27 b.iii - Allowing engine to idle one minute");
         int minuteCounter = 60;
         for (int i = minuteCounter; i > 0; i--) {
-            expectedMessages.append(NL).append("Allowing engine to idle for ").append(i).append(" seconds");
+            expectedMessages.append(NL).append("Step 1.27.b.iii Allowing engine to idle for ").append(i).append(" seconds");
         }
         assertEquals(expectedMessages.toString(), listener.getMessages());
 

--- a/src-test/org/etools/j1939_84/controllers/part01/SectionA5VerifierTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/SectionA5VerifierTest.java
@@ -88,15 +88,15 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     private VehicleInformationModule vehicleInformationModule;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         DateTimeModule.setInstance(new TestDateTimeModule());
         listener = new TestResultsListener(mockListener);
 
-        instance = new SectionA5Verifier(dataRepository, diagnosticMessageModule, vehicleInformationModule);
+        instance = new SectionA5Verifier(dataRepository, diagnosticMessageModule, vehicleInformationModule, 1,1);
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         DateTimeModule.setInstance(null);
         verifyNoMoreInteractions(dataRepository,
                                  diagnosticMessageModule,
@@ -104,17 +104,11 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
                                  vehicleInformationModule);
     }
 
-    /**
-     * Test method for
-     * {@link org.etools.j1939_84.controllers.part01.SectionA5Verifier#setJ1939(org.etools.j1939_84.bus.j1939.J1939)}.
-     */
+
     @Test
     public void testSetJ1939() {
-
         instance.setJ1939(j1939);
-
         verify(diagnosticMessageModule).setJ1939(j1939);
-
         verify(vehicleInformationModule).setJ1939(j1939);
     }
 

--- a/src/org/etools/j1939_84/bus/j1939/packets/DM3DiagnosticDataClearPacket.java
+++ b/src/org/etools/j1939_84/bus/j1939/packets/DM3DiagnosticDataClearPacket.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 Equipment & Tool Institute
+ */
+package org.etools.j1939_84.bus.j1939.packets;
+
+import org.etools.j1939_84.bus.Packet;
+import org.etools.j1939_84.bus.j1939.J1939DaRepository;
+
+/**
+ * The DM3 Packet. This isn't used to parse any packets as it will only be sent
+ * to the vehicle. Responses will be {@link AcknowledgmentPacket}
+ *
+ * @author Matt Gumbel (matt@soliddesign.net)
+ *
+ */
+public class DM3DiagnosticDataClearPacket extends GenericPacket {
+
+    public static final int PGN = 65228; // 0xFECC
+
+    public DM3DiagnosticDataClearPacket(Packet packet) {
+        super(packet, new J1939DaRepository().findPgnDefinition(PGN));
+    }
+
+    @Override
+    public String getName() {
+        return "DM3";
+    }
+
+}

--- a/src/org/etools/j1939_84/controllers/part01/Part01Step27Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step27Controller.java
@@ -82,7 +82,7 @@ public class Part01Step27Controller extends StepController {
         //      iii. The engine shall be allowed to idle one minute
         incrementProgress("Part 1, Step 27 b.iii - Allowing engine to idle one minute");
         if (!isDevEnv()) {
-            pause("Allowing engine to idle for %1$d seconds", 60L);
+            pause("Step 1.27.b.iii Allowing engine to idle for %1$d seconds", 60L);
         }
     }
 

--- a/src/org/etools/j1939_84/controllers/part01/SectionA5Verifier.java
+++ b/src/org/etools/j1939_84/controllers/part01/SectionA5Verifier.java
@@ -4,6 +4,7 @@
 package org.etools.j1939_84.controllers.part01;
 
 import static org.etools.j1939_84.J1939_84.NL;
+import static org.etools.j1939_84.model.Outcome.INCOMPLETE;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -42,24 +43,34 @@ public class SectionA5Verifier {
 
     private final DataRepository dataRepository;
     private final DiagnosticMessageModule diagnosticMessageModule;
-
     private final VehicleInformationModule vehicleInformationModule;
+    private final int partNumber;
+    private final int stepNumber;
 
-    public SectionA5Verifier(DataRepository dataRepository) {
-        this(dataRepository, new DiagnosticMessageModule(), new VehicleInformationModule());
+    public SectionA5Verifier(int partNumber, int stepNumber) {
+        this(DataRepository.getInstance(), new DiagnosticMessageModule(), new VehicleInformationModule(), partNumber, stepNumber);
     }
 
     protected SectionA5Verifier(DataRepository dataRepository,
                                 DiagnosticMessageModule diagnosticMessageModule,
-                                VehicleInformationModule vehicleInformationModule) {
+                                VehicleInformationModule vehicleInformationModule,
+                                int partNumber,
+                                int stepNumber) {
         this.dataRepository = dataRepository;
         this.diagnosticMessageModule = diagnosticMessageModule;
         this.vehicleInformationModule = vehicleInformationModule;
+        this.partNumber = partNumber;
+        this.stepNumber = stepNumber;
     }
 
     public void setJ1939(J1939 j1939) {
         diagnosticMessageModule.setJ1939(j1939);
         vehicleInformationModule.setJ1939(j1939);
+    }
+
+    public void verifyDataNotErased(ResultsListener listener, String section) {
+        //TODO
+        listener.addOutcome(partNumber, stepNumber, INCOMPLETE, section +" - hasn't finishing implementing this");
     }
 
     public boolean verify(List<DM28PermanentEmissionDTCPacket> previousDM28Packets,

--- a/src/org/etools/j1939_84/modules/DiagnosticMessageModule.java
+++ b/src/org/etools/j1939_84/modules/DiagnosticMessageModule.java
@@ -17,9 +17,11 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.etools.j1939_84.bus.j1939.BusResult;
+import org.etools.j1939_84.bus.j1939.Lookup;
 import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket;
 import org.etools.j1939_84.bus.j1939.packets.CompositeMonitoredSystem;
 import org.etools.j1939_84.bus.j1939.packets.CompositeSystem;
+import org.etools.j1939_84.bus.j1939.packets.DM11ClearActiveDTCsPacket;
 import org.etools.j1939_84.bus.j1939.packets.DM12MILOnEmissionDTCPacket;
 import org.etools.j1939_84.bus.j1939.packets.DM1ActiveDTCsPacket;
 import org.etools.j1939_84.bus.j1939.packets.DM20MonitorPerformanceRatioPacket;
@@ -36,6 +38,7 @@ import org.etools.j1939_84.bus.j1939.packets.DM30ScaledTestResultsPacket;
 import org.etools.j1939_84.bus.j1939.packets.DM31DtcToLampAssociation;
 import org.etools.j1939_84.bus.j1939.packets.DM33EmissionIncreasingAECDActiveTime;
 import org.etools.j1939_84.bus.j1939.packets.DM34NTEStatus;
+import org.etools.j1939_84.bus.j1939.packets.DM3DiagnosticDataClearPacket;
 import org.etools.j1939_84.bus.j1939.packets.DM56EngineFamilyPacket;
 import org.etools.j1939_84.bus.j1939.packets.DM5DiagnosticReadinessPacket;
 import org.etools.j1939_84.bus.j1939.packets.DM6PendingEmissionDTCPacket;
@@ -103,6 +106,17 @@ public class DiagnosticMessageModule extends FunctionalModule {
         return requestDMPackets("DM2", DM2PreviouslyActiveDTC.class, address, listener).busResult();
     }
 
+    public List<AcknowledgmentPacket> requestDM3(ResultsListener listener) {
+        return getJ1939().requestForAcks(listener, "Global DM3 Request", DM3DiagnosticDataClearPacket.PGN);
+    }
+
+    public List<AcknowledgmentPacket> requestDM3(ResultsListener listener, int address) {
+        return getJ1939().requestForAcks(listener,
+                                         "DS DM3 Request to " + Lookup.getAddressName(address),
+                                         DM3DiagnosticDataClearPacket.PGN,
+                                         address);
+    }
+
     public RequestResult<DM5DiagnosticReadinessPacket> requestDM5(ResultsListener listener) {
         return requestDMPackets("DM5", DM5DiagnosticReadinessPacket.class, GLOBAL_ADDR, listener);
     }
@@ -120,7 +134,7 @@ public class DiagnosticMessageModule extends FunctionalModule {
     }
 
     public List<AcknowledgmentPacket> requestDM11(ResultsListener listener) {
-        return getJ1939().requestDM11(listener);
+        return getJ1939().requestForAcks(listener, "Global DM11 Request", DM11ClearActiveDTCsPacket.PGN);
     }
 
     public RequestResult<DM12MILOnEmissionDTCPacket> requestDM12(ResultsListener listener) {


### PR DESCRIPTION
This implements most of Part 4 Step 13.  It doesn't check that diagnostic data has been cleared.  That's supposed to be done with the `SectionA5Verifier`  However, we removed that from use in part 1 as Eric suggested it was excessive.  Once we have a clear direction from Eric last next week, I'll fix it with #603 