### PR TITLE
Implement Part 6 Step 7

### DIFF
--- a/src/org/etools/j1939_84/bus/j1939/BusResult.java
+++ b/src/org/etools/j1939_84/bus/j1939/BusResult.java
@@ -60,6 +60,14 @@ public class BusResult<T extends ParsedPacket> {
         return new BusResult<>(false);
     }
 
+    public static <T extends ParsedPacket> BusResult<T> of(T packet) {
+        return new BusResult<>(false, packet);
+    }
+
+    public static <T extends ParsedPacket> BusResult<T> of(AcknowledgmentPacket packet) {
+        return new BusResult<>(false, packet);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (o instanceof BusResult) {

--- a/src/org/etools/j1939_84/controllers/part06/Part06Step07Controller.java
+++ b/src/org/etools/j1939_84/controllers/part06/Part06Step07Controller.java
@@ -3,9 +3,16 @@
  */
 package org.etools.j1939_84.controllers.part06;
 
+import static org.etools.j1939_84.bus.j1939.packets.LampStatus.ON;
+
+import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
 
+import org.etools.j1939_84.bus.j1939.packets.DM12MILOnEmissionDTCPacket;
+import org.etools.j1939_84.bus.j1939.packets.DiagnosticTroubleCode;
+import org.etools.j1939_84.bus.j1939.packets.DiagnosticTroubleCodePacket;
 import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.modules.BannerModule;
@@ -53,11 +60,50 @@ public class Part06Step07Controller extends StepController {
 
     @Override
     protected void run() throws Throwable {
-        // 6.6.7.1.a DS DM28 [(send Request (PGN 59904) for PGN 64896 (SPNS 1213-1215, 3038, 1706))] to each OBD ECU.
+        // 6.6.7.1.a DS DM28 [(send Request (PGN 59904) for PGN 64896 (SPNs 1213-1215, 3038, 1706))] to each OBD ECU.
+        var dsResults = getDataRepository().getObdModuleAddresses()
+                                           .stream()
+                                           .map(a -> getDiagnosticMessageModule().requestDM28(getListener(), a))
+                                           .collect(Collectors.toList());
+
+        var packets = filterPackets(dsResults);
+
         // 6.6.7.2.a. Fail if no ECU reports permanent DTC present.
+        boolean noDTCs = packets.stream().map(DiagnosticTroubleCodePacket::getDtcs).allMatch(List::isEmpty);
+        if (noDTCs) {
+            addFailure("6.6.7.2.a - No ECU reported permanent DTC");
+        }
+
         // 6.6.7.2.b. Fail if permanent DTC provided does not match DM12 active DTC.
+        packets.forEach(p -> {
+            List<DiagnosticTroubleCode> dm12DTCs = getDTCs(p.getSourceAddress());
+            List<DiagnosticTroubleCode> dm28DTCs = p.getDtcs();
+
+            for (DiagnosticTroubleCode dtc : dm12DTCs) {
+                if (!listContainsDTC(dm28DTCs, dtc)) {
+                    int spn = dtc.getSuspectParameterNumber();
+                    int fmi = dtc.getFailureModeIndicator();
+                    addFailure("6.6.7.2.b - The DTC (" + spn + ":" + fmi + ") provided by " + p.getModuleName()
+                            + " does not match DM12 active DTC");
+                }
+            }
+        });
+
         // 6.6.7.2.c. Fail if no ECU reports MIL on.
+        boolean noMil = packets.stream()
+                               .map(DiagnosticTroubleCodePacket::getMalfunctionIndicatorLampStatus)
+                               .noneMatch(mil -> mil == ON);
+        if (noMil) {
+            addFailure("6.6.7.2.c - No ECU reported MIL on");
+        }
+
         // 6.6.7.2.d. Fail if NACK not received from OBD ECUs that did not provide a DM28 message.
+        checkForNACKsFromObdModules(packets, filterAcks(dsResults), "6.6.7.2.d");
+    }
+
+    private List<DiagnosticTroubleCode> getDTCs(int moduleAddress) {
+        var packet = get(DM12MILOnEmissionDTCPacket.class, moduleAddress);
+        return packet == null ? List.of() : packet.getDtcs();
     }
 
 }

--- a/src/org/etools/j1939_84/model/RequestResult.java
+++ b/src/org/etools/j1939_84/model/RequestResult.java
@@ -49,14 +49,14 @@ public class RequestResult<T extends ParsedPacket> {
     public RequestResult(boolean retryUsed, T... packets) {
         this.retryUsed = retryUsed;
         this.packets = Arrays.asList(packets);
-        this.acks = Collections.emptyList();
+        acks = Collections.emptyList();
     }
 
     @SafeVarargs
     public <TP extends AcknowledgmentPacket> RequestResult(boolean retryUsed, TP... packets) {
         this.retryUsed = retryUsed;
         this.packets = Collections.emptyList();
-        this.acks = Arrays.asList(packets);
+        acks = Arrays.asList(packets);
     }
 
     public static <S extends ParsedPacket> RequestResult<S> empty() {
@@ -65,6 +65,11 @@ public class RequestResult<T extends ParsedPacket> {
 
     public static <S extends ParsedPacket> RequestResult<S> empty(boolean retry) {
         return new RequestResult<>(retry, Collections.emptyList());
+    }
+
+    @SafeVarargs
+    public static <S extends ParsedPacket> RequestResult<S> of(S... packets) {
+        return new RequestResult<>(false, packets);
     }
 
     public List<AcknowledgmentPacket> getAcks() {
@@ -101,9 +106,9 @@ public class RequestResult<T extends ParsedPacket> {
         }
 
         RequestResult<?> that = (RequestResult<?>) obj;
-        return this.isRetryUsed() == that.isRetryUsed()
-                && Objects.equals(this.getPackets(), that.getPackets())
-                && Objects.equals(this.getAcks(), that.getAcks());
+        return isRetryUsed() == that.isRetryUsed()
+                && Objects.equals(getPackets(), that.getPackets())
+                && Objects.equals(getAcks(), that.getAcks());
     }
 
     @Override
@@ -114,24 +119,24 @@ public class RequestResult<T extends ParsedPacket> {
           .append(isRetryUsed())
           .append(NL)
           .append("Response packets :");
-        this.getPackets()
+        getPackets()
             .forEach(packet -> sb.append(NL)
                                  .append("Source address : ")
                                  .append(packet.getSourceAddress())
                                  .append(" returned ")
                                  .append(packet.toString()));
-        if (this.getPackets().isEmpty()) {
+        if (getPackets().isEmpty()) {
             sb.append(NL).append("No packets returned");
         }
         sb.append(NL)
           .append("Ack packets :");
-        this.getAcks()
+        getAcks()
             .forEach(ack -> sb.append(NL)
                               .append("Source address : ")
                               .append(ack.getSourceAddress())
                               .append(" returned ")
                               .append(ack.toString()));
-        if (this.getAcks().isEmpty()) {
+        if (getAcks().isEmpty()) {
             sb.append(NL).append("No acks returned");
         }
 


### PR DESCRIPTION
I also added new methods called `of()` in the `BusResult` and `RequestResult` classes to make it simpler to return a result from a test mock.

```
        when(diagnosticMessageModule.requestDM28(any(), eq(0))).thenReturn(BusResult.of(dm28));
```