### PR TITLE
Add part 06 step 11

### DIFF
--- a/src-test/org/etools/j1939_84/controllers/part06/Part06Step11ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part06/Part06Step11ControllerTest.java
@@ -3,13 +3,25 @@
  */
 package org.etools.j1939_84.controllers.part06;
 
+import static org.etools.j1939_84.J1939_84.NL;
+import static org.etools.j1939_84.controllers.QuestionListener.AnswerType.NO;
+import static org.etools.j1939_84.controllers.QuestionListener.AnswerType.YES;
+import static org.etools.j1939_84.controllers.ResultsListener.MessageType.WARNING;
+import static org.etools.j1939_84.model.Outcome.ABORT;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
+import java.util.Timer;
+import java.util.TimerTask;
 import java.util.concurrent.Executor;
 
 import org.etools.j1939_84.bus.j1939.J1939;
 import org.etools.j1939_84.controllers.DataRepository;
+import org.etools.j1939_84.controllers.QuestionListener;
 import org.etools.j1939_84.controllers.ResultsListener;
 import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.controllers.TestResultsListener;
@@ -18,13 +30,13 @@ import org.etools.j1939_84.modules.DateTimeModule;
 import org.etools.j1939_84.modules.DiagnosticMessageModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.ReportFileModule;
-import org.etools.j1939_84.modules.TestDateTimeModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
 import org.etools.j1939_84.utils.AbstractControllerTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -70,7 +82,7 @@ public class Part06Step11ControllerTest extends AbstractControllerTest {
 
         instance = new Part06Step11Controller(executor,
                                               bannerModule,
-                                              new TestDateTimeModule(),
+                                              DateTimeModule.getInstance(),
                                               dataRepository,
                                               engineSpeedModule,
                                               vehicleInformationModule,
@@ -120,10 +132,280 @@ public class Part06Step11ControllerTest extends AbstractControllerTest {
     @Test
     public void testHappyPathNoFailures() {
 
+        when(engineSpeedModule.isEngineCommunicating()).thenReturn(false, true, false);
+        when(engineSpeedModule.getEngineSpeedAsString()).thenReturn("0.0 RPMs", "500.0 RPMs");
+
+        new Timer().schedule(new TimerTask() {
+            @Override
+            public void run() {
+                when(engineSpeedModule.isEngineNotRunning()).thenReturn(true);
+            }
+        }, 750);
+
+        ArgumentCaptor<QuestionListener> questionCaptor = ArgumentCaptor.forClass(QuestionListener.class);
         runTest();
 
-        assertEquals("", listener.getMessages());
-        assertEquals("", listener.getResults());
+        verify(engineSpeedModule, atLeastOnce()).isEngineCommunicating();
+        verify(engineSpeedModule, atLeastOnce()).getEngineSpeedAsString();
+
+        String urgentMessages = "Please wait for the manufacturer's recommended interval with the key in off position"
+                + NL;
+        urgentMessages += "Press OK to continue the testing" + NL;
+        String expectedTitle = "Step 6.6.11.1.b";
+        verify(mockListener).onUrgentMessage(eq(urgentMessages),
+                                             eq(expectedTitle),
+                                             eq(WARNING),
+                                             questionCaptor.capture());
+        questionCaptor.getValue().answered(YES);
+
+        String urgentMessages1 = "Please turn the Key ON with Engine OFF";
+        String expectedTitle1 = "Adjust Key Switch";
+        verify(mockListener).onUrgentMessage(eq(urgentMessages1), eq(expectedTitle1), eq(WARNING));
+
+        String urgentMessages2 = "If required by engine manufacturer, start the engine for start to start operating cycle effects"
+                + NL;
+        urgentMessages2 += "Press OK when when ready to continue testing" + NL;
+        String expectedTitle2 = "Step 6.6.11.d & e";
+        verify(mockListener).onUrgentMessage(eq(urgentMessages2),
+                                             eq(expectedTitle2),
+                                             eq(WARNING),
+                                             questionCaptor.capture());
+        questionCaptor.getValue().answered(YES);
+
+        String urgentMessages3 = "Please turn the Key OFF with Engine OFF";
+        String expectedTitle3 = "Adjust Key Switch";
+        verify(mockListener).onUrgentMessage(eq(urgentMessages3), eq(expectedTitle3), eq(WARNING));
+
+        String urgentMessages4 = "Please wait for the manufacturer's recommended interval with the key in off position"
+                + NL;
+        urgentMessages4 += "Press OK to continue the testing" + NL;
+        String expectedTitle4 = "Step 6.6.11.1.g";
+        verify(mockListener).onUrgentMessage(eq(urgentMessages4),
+                                             eq(expectedTitle4),
+                                             eq(WARNING),
+                                             questionCaptor.capture());
+        questionCaptor.getValue().answered(YES);
+
+        String urgentMessages5 = "Turn the key to the on position" + NL;
+        urgentMessages5 += "Proceeding with Part 7" + NL;
+        urgentMessages5 += "Press OK when ready to continue testing" + NL;
+        String expectedTitle5 = "Step 6.6.11.1.h-i";
+        verify(mockListener).onUrgentMessage(eq(urgentMessages5),
+                                             eq(expectedTitle5),
+                                             eq(WARNING),
+                                             questionCaptor.capture());
+        questionCaptor.getValue().answered(YES);
+
+        String expectedMessages = "Step 6.6.11.1.a - Turn Engine Off and keep the ignition key in the off position"
+                + NL;
+        expectedMessages += "Step 6.6.11.1.b - Waiting manufacturer’s recommended interval with the key in the off position"
+                + NL;
+        expectedMessages += "6.6.11.1.c Turn the ignition key in the on position" + NL;
+        expectedMessages += "Waiting for Key ON, Engine OFF..." + NL;
+        expectedMessages += "Waiting for Key ON, Engine OFF..." + NL;
+        expectedMessages += "Step 6.6.11.g - Waiting manufacturer’s recommended interval with the key in the off position";
+        assertEquals(expectedMessages, listener.getMessages());
+
+        assertEquals("", listener.getMilestones());
+        String expected = "Initial Engine Speed = 0.0 RPMs" + NL;
+        expected += "Final Engine Speed = 500.0 RPMs" + NL;
+        expected += "Initial Engine Speed = 500.0 RPMs" + NL;
+        expected += "Final Engine Speed = 500.0 RPMs" + NL;
+        expected += "Initial Engine Speed = 500.0 RPMs" + NL;
+        expected += "Final Engine Speed = 500.0 RPMs" + NL;
+
+        assertEquals(expected, listener.getResults());
+        assertEquals("", listener.getMilestones());
+
+        verify(engineSpeedModule, atLeastOnce()).isEngineNotRunning();
     }
 
+    @Test
+    public void testUserAbortForFail() {
+
+        when(engineSpeedModule.isEngineCommunicating()).thenReturn(false);
+        when(engineSpeedModule.getEngineSpeedAsString()).thenReturn("0.0 RPMs", "500.0 RPMs");
+
+        new Timer().schedule(new TimerTask() {
+            @Override
+            public void run() {
+                when(engineSpeedModule.isEngineNotRunning()).thenReturn(true);
+            }
+        }, 750);
+        ArgumentCaptor<QuestionListener> questionCaptor = ArgumentCaptor.forClass(QuestionListener.class);
+
+        runTest();
+
+        verify(engineSpeedModule, atLeastOnce()).isEngineCommunicating();
+        verify(engineSpeedModule, atLeastOnce()).isEngineNotRunning();
+        verify(engineSpeedModule, atLeastOnce()).getEngineSpeedAsString();
+
+        String urgentMessages = "Please wait for the manufacturer's recommended interval with the key in off position"
+                + NL;
+        urgentMessages += "Press OK to continue the testing" + NL;
+        String expectedTitle = "Step 6.6.11.1.b";
+        verify(mockListener).onUrgentMessage(eq(urgentMessages),
+                                             eq(expectedTitle),
+                                             eq(WARNING),
+                                             questionCaptor.capture());
+        questionCaptor.getValue().answered(YES);
+
+        String urgentMessages1 = "Please turn the Key ON with Engine OFF";
+        String expectedTitle1 = "Adjust Key Switch";
+        verify(mockListener).onUrgentMessage(eq(urgentMessages1), eq(expectedTitle1), eq(WARNING));
+
+        String urgentMessages2 = "If required by engine manufacturer, start the engine for start to start operating cycle effects"
+                + NL;
+        urgentMessages2 += "Press OK when when ready to continue testing" + NL;
+        String expectedTitle2 = "Step 6.6.11.d & e";
+        verify(mockListener).onUrgentMessage(eq(urgentMessages2),
+                                             eq(expectedTitle2),
+                                             eq(WARNING),
+                                             questionCaptor.capture());
+        questionCaptor.getValue().answered(NO);
+
+        // String urgentMessages3 = "Please turn the Key OFF with Engine OFF";
+        // String expectedTitle3 = "Adjust Key Switch";
+        // verify(mockListener).onUrgentMessage(eq(urgentMessages3),
+        // eq(expectedTitle3),
+        // eq(WARNING),
+        // questionCaptor.capture());
+
+        String urgentMessages4 = "Please wait for the manufacturer's recommended interval with the key in off position"
+                + NL;
+        urgentMessages4 += "Press OK to continue the testing" + NL;
+        String expectedTitle4 = "Step 6.6.11.1.g";
+        verify(mockListener).onUrgentMessage(eq(urgentMessages4),
+                                             eq(expectedTitle4),
+                                             eq(WARNING),
+                                             questionCaptor.capture());
+
+        String urgentMessages5 = "Turn the key to the on position" + NL;
+        urgentMessages5 += "Proceeding with Part 7" + NL;
+        urgentMessages5 += "Press OK when ready to continue testing" + NL;
+        String expectedTitle5 = "Step 6.6.11.1.h-i";
+        verify(mockListener).onUrgentMessage(eq(urgentMessages5),
+                                             eq(expectedTitle5),
+                                             eq(WARNING),
+                                             questionCaptor.capture());
+
+        verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, ABORT, "User cancelled testing at Part 6 Step 11");
+
+        String expectedMessages = "Step 6.6.11.1.a - Turn Engine Off and keep the ignition key in the off position"
+                + NL;
+        expectedMessages += "Step 6.6.11.1.b - Waiting manufacturer’s recommended interval with the key in the off position"
+                + NL;
+        expectedMessages += "6.6.11.1.c Turn the ignition key in the on position" + NL;
+        expectedMessages += "Waiting for Key ON, Engine OFF..." + NL;
+        expectedMessages += "Waiting for Key ON, Engine OFF..." + NL;
+        expectedMessages += "Step 6.6.11.g - Waiting manufacturer’s recommended interval with the key in the off position"
+                + NL;
+        expectedMessages += "User cancelled testing at Part 6 Step 11";
+        assertEquals(expectedMessages, listener.getMessages());
+
+        String expectedResults = "";
+        expectedResults += "Initial Engine Speed = 0.0 RPMs" + NL;
+        expectedResults += "Final Engine Speed = 500.0 RPMs" + NL;
+        expectedResults += "Initial Engine Speed = 500.0 RPMs" + NL;
+        expectedResults += "Final Engine Speed = 500.0 RPMs" + NL;
+        expectedResults += "Initial Engine Speed = 500.0 RPMs" + NL;
+        expectedResults += "Final Engine Speed = 500.0 RPMs" + NL;
+        assertEquals(expectedResults, listener.getResults());
+
+    }
+
+    @Test
+    public void testEngineThrowInterruptedException() {
+
+        when(engineSpeedModule.isEngineCommunicating()).thenReturn(false);
+        when(engineSpeedModule.getEngineSpeedAsString()).thenReturn("0.0 RPMs");
+
+        new Timer().schedule(new TimerTask() {
+            @Override
+            public void run() {
+                when(engineSpeedModule.isEngineNotRunning()).thenReturn(true);
+            }
+        }, 750);
+        ArgumentCaptor<QuestionListener> questionCaptor = ArgumentCaptor.forClass(QuestionListener.class);
+
+        runTest();
+
+        verify(engineSpeedModule).setJ1939(j1939);
+        verify(engineSpeedModule, atLeastOnce()).isEngineNotRunning();
+        verify(engineSpeedModule, atLeastOnce()).isEngineCommunicating();
+        verify(engineSpeedModule, atLeastOnce()).getEngineSpeedAsString();
+
+        String urgentMessages = "Please wait for the manufacturer's recommended interval with the key in off position"
+                + NL;
+        urgentMessages += "Press OK to continue the testing" + NL;
+        String expectedTitle = "Step 6.6.11.1.b";
+        verify(mockListener).onUrgentMessage(eq(urgentMessages),
+                                             eq(expectedTitle),
+                                             eq(WARNING),
+                                             questionCaptor.capture());
+        questionCaptor.getValue().answered(YES);
+
+        String urgentMessages1 = "Please turn the Key ON with Engine OFF";
+        String expectedTitle1 = "Adjust Key Switch";
+        verify(mockListener).onUrgentMessage(eq(urgentMessages1), eq(expectedTitle1), eq(WARNING));
+
+        String urgentMessages2 = "If required by engine manufacturer, start the engine for start to start operating cycle effects"
+                + NL;
+        urgentMessages2 += "Press OK when when ready to continue testing" + NL;
+        String expectedTitle2 = "Step 6.6.11.d & e";
+        verify(mockListener).onUrgentMessage(eq(urgentMessages2),
+                                             eq(expectedTitle2),
+                                             eq(WARNING),
+                                             questionCaptor.capture());
+        questionCaptor.getValue().answered(NO);
+
+        // String urgentMessages3 = "Please turn the Key OFF with Engine OFF";
+        // String expectedTitle3 = "Adjust Key Switch";
+        // verify(mockListener).onUrgentMessage(eq(urgentMessages3), eq(expectedTitle3), eq(WARNING), any());
+
+        String urgentMessages4 = "Please wait for the manufacturer's recommended interval with the key in off position"
+                + NL;
+        urgentMessages4 += "Press OK to continue the testing" + NL;
+        String expectedTitle4 = "Step 6.6.11.1.g";
+        verify(mockListener).onUrgentMessage(eq(urgentMessages4),
+                                             eq(expectedTitle4),
+                                             eq(WARNING),
+                                             questionCaptor.capture());
+
+        String urgentMessages5 = "Turn the key to the on position" + NL;
+        urgentMessages5 += "Proceeding with Part 7" + NL;
+        urgentMessages5 += "Press OK when ready to continue testing" + NL;
+        String expectedTitle5 = "Step 6.6.11.1.h-i";
+        verify(mockListener).onUrgentMessage(eq(urgentMessages5),
+                                             eq(expectedTitle5),
+                                             eq(WARNING),
+                                             questionCaptor.capture());
+
+        verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, ABORT, "User cancelled testing at Part 6 Step 11");
+
+        String expectedMessages = "Step 6.6.11.1.a - Turn Engine Off and keep the ignition key in the off position"
+                + NL;
+        expectedMessages += "Step 6.6.11.1.b - Waiting manufacturer’s recommended interval with the key in the off position"
+                + NL;
+        expectedMessages += "6.6.11.1.c Turn the ignition key in the on position" + NL;
+        expectedMessages += "Waiting for Key ON, Engine OFF..." + NL;
+        expectedMessages += "Waiting for Key ON, Engine OFF..." + NL;
+        expectedMessages += "Step 6.6.11.g - Waiting manufacturer’s recommended interval with the key in the off position"
+                + NL;
+        expectedMessages += "User cancelled testing at Part 6 Step 11";
+        assertEquals(expectedMessages, listener.getMessages());
+
+        assertEquals("", listener.getMilestones());
+
+        String expectedResults = "";
+        expectedResults += "Initial Engine Speed = 0.0 RPMs" + NL;
+        expectedResults += "Final Engine Speed = 0.0 RPMs" + NL;
+        expectedResults += "Initial Engine Speed = 0.0 RPMs" + NL;
+        expectedResults += "Final Engine Speed = 0.0 RPMs" + NL;
+        expectedResults += "Initial Engine Speed = 0.0 RPMs" + NL;
+        expectedResults += "Final Engine Speed = 0.0 RPMs" + NL;
+        assertEquals(expectedResults, listener.getResults());
+
+        assertEquals("", listener.getMilestones());
+    }
 }

--- a/src/org/etools/j1939_84/controllers/StepController.java
+++ b/src/org/etools/j1939_84/controllers/StepController.java
@@ -377,4 +377,13 @@ public abstract class StepController extends Controller {
         }
     }
 
+    protected void waitForManufacturerInterval(String boxTitle) {
+        if (!isDevEnv()) {
+            String message = "Please wait for the manufacturer's recommended interval with the key in off position"
+                    + NL;
+            message += "Press OK to continue the testing" + NL;
+            displayInstructionAndWait(message, boxTitle, WARNING);
+        }
+    }
+
 }

--- a/src/org/etools/j1939_84/controllers/part03/Part03Step16Controller.java
+++ b/src/org/etools/j1939_84/controllers/part03/Part03Step16Controller.java
@@ -68,7 +68,7 @@ public class Part03Step16Controller extends StepController {
 
         // 6.3.16.1.c. Wait manufacturer’s recommended interval with the key in the off position.
         incrementProgress("Waiting for manufacturer's recommended interval with the key in off position");
-        waitForManufacturerInterval();
+        waitForManufacturerInterval("6.3.16.1.c");
 
         // 6.3.16.1.d. Turn ignition key to the ON position.
         // 6.3.16.1.e. Observe MIL and Wait to Start Lamp in Instrument Cluster
@@ -83,15 +83,6 @@ public class Part03Step16Controller extends StepController {
         String boxTitle = "Part 6.3.16.1.b";
         if (!isDevEnv()) {
             displayInstructionAndWait(message, boxTitle, WARNING);
-        }
-    }
-
-    private void waitForManufacturerInterval() {
-        if (!isDevEnv()) {
-            String message = "Please wait for the manufacturer's recommended interval with the key in off position"
-                    + NL;
-            message += "Press OK to continue the testing" + NL;
-            displayInstructionAndWait(message, "Part 6.3.16.1.c", WARNING);
         }
     }
 

--- a/src/org/etools/j1939_84/controllers/part04/Part04Step15Controller.java
+++ b/src/org/etools/j1939_84/controllers/part04/Part04Step15Controller.java
@@ -63,7 +63,7 @@ public class Part04Step15Controller extends StepController {
 
         // 6.4.15.1.b Wait engine manufacturer’s recommended interval.
         incrementProgress("Waiting for manufacturer's recommended interval with the key in off position");
-        waitForManufacturerInterval();
+        waitForManufacturerInterval("6.4.15.1.b");
 
         // 6.4.15.1.c With the key in the off position remove the implanted Fault A according to the
         // manufacturer’s instructions for restoring the system to a fault- free operating condition.
@@ -75,15 +75,6 @@ public class Part04Step15Controller extends StepController {
         // 6.4.15.1.f Start Engine after MIL and Wait to Start Lamp (if equipped) have extinguished.
         // 6.4.15.1.g Wait for manufacturer’s recommended time for Fault A to be detected (as passed).
         waitForEngineStart();
-    }
-
-    private void waitForManufacturerInterval() {
-        if (!isDevEnv()) {
-            String message = "Please wait for the manufacturer's recommended interval with the key in off position"
-                    + NL;
-            message += "Press OK to continue the testing" + NL;
-            displayInstructionAndWait(message, "Part 6.4.15.1.b", WARNING);
-        }
     }
 
     private void confirmFaultRemoved() {

--- a/src/org/etools/j1939_84/controllers/part05/Part05Step07Controller.java
+++ b/src/org/etools/j1939_84/controllers/part05/Part05Step07Controller.java
@@ -55,11 +55,11 @@ public class Part05Step07Controller extends StepController {
     @Override
     protected void run() throws Throwable {
         // 6.5.7.1.a Turn the engine off to complete the first1st cycle.
-        incrementProgress("Step 5.7.1.a - Turn Engine Off and keep the ignition key in the off position");
+        incrementProgress("Step 6.5.7.1.a - Turn Engine Off and keep the ignition key in the off position");
         ensureKeyOffEngineOff();
 
         // 6.5.7.1.b Wait manufacturer’s recommended interval with the key in the off position.
-        incrementProgress("Step 5.7.1.b - Waiting manufacturer’s recommended interval with the key in the off position");
+        incrementProgress("Step 6.5.7.1.b - Waiting manufacturer’s recommended interval with the key in the off position");
         waitForManufacturerInterval("Part 6.5.7.1.b");
 
         // 6.5.7.1.c Start Engine for second cycle.
@@ -75,15 +75,6 @@ public class Part05Step07Controller extends StepController {
         // 6.5.7.1.g Start the engine for part 6.
         // 6.5.7.1.h Wait for manufacturer’s recommended time for Fault A to be detected as passed
         waitForEngineStart();
-    }
-
-    private void waitForManufacturerInterval(String boxTitle) {
-        if (!isDevEnv()) {
-            String message = "Please wait for the manufacturer's recommended interval with the key in off position"
-                    + NL;
-            message += "Press OK to continue the testing" + NL;
-            displayInstructionAndWait(message, boxTitle, WARNING);
-        }
     }
 
     private void waitForEngineStart() {

--- a/src/org/etools/j1939_84/controllers/part06/Part06Step11Controller.java
+++ b/src/org/etools/j1939_84/controllers/part06/Part06Step11Controller.java
@@ -3,6 +3,10 @@
  */
 package org.etools.j1939_84.controllers.part06;
 
+import static org.etools.j1939_84.J1939_84.NL;
+import static org.etools.j1939_84.J1939_84.isDevEnv;
+import static org.etools.j1939_84.controllers.ResultsListener.MessageType.WARNING;
+
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
@@ -54,14 +58,55 @@ public class Part06Step11Controller extends StepController {
     @Override
     protected void run() throws Throwable {
         // 6.6.11.1.a Turn engine off.
+        incrementProgress("Step 6.6.11.1.a - Turn Engine Off and keep the ignition key in the off position");
+        ensureKeyOffEngineOff();
+
         // 6.6.11.1.b Wait engine manufacturer’s recommended interval.
+        incrementProgress("Step 6.6.11.1.b - Waiting manufacturer’s recommended interval with the key in the off position");
+        waitForManufacturerInterval("Step 6.6.11.1.b");
+
         // 6.6.11.1.c Turn key to on position.
+        incrementProgress("6.6.11.1.c Turn the ignition key in the on position");
+        ensureKeyOnEngineOff();
+
         // 6.6.11.1.d If required by engine manufacturer, start the engine for start to start operating cycle effects.
         // 6.6.11.1.e Otherwise, Proceed with part 7.
+        displayQuestionMessage();
+
         // 6.6.11.1.f Turn engine off.
+        ensureKeyOffEngineOff();
+
         // 6.6.11.1.g Wait engine manufacturer’s recommended interval.
+        incrementProgress("Step 6.6.11.g - Waiting manufacturer’s recommended interval with the key in the off position");
+        waitForManufacturerInterval("Step 6.6.11.1.g");
+
         // 6.6.11.1.h Turn the key to the on position.
         // 6.6.11.1.i Proceed with part 7.
+        waitForEngineStart();
+    }
+
+    private void waitForEngineStart() {
+        if (!isDevEnv()) {
+            String message = "Turn the key to the on position" + NL;
+            message += "Proceeding with Part 7" + NL;
+            message += "Press OK when ready to continue testing" + NL;
+            displayInstructionAndWait(message, "Step 6.6.11.1.h-i", WARNING);
+        }
+    }
+
+    private void displayQuestionMessage() {
+
+        // 6.6.11.1.d If required by engine manufacturer, start the engine for start to start operating cycle effects.
+        // 6.6.11.1.e Otherwise, Proceed with part 7.
+        if (!isDevEnv()) {
+            // a. Testing may be stopped for vehicles with failed tests and for vehicles with the MIL on
+            // or a non-emissions related fault displayed in DM1. Vehicles with the MIL on will fail subsequent tests.
+            String message = "If required by engine manufacturer, start the engine for start to start operating cycle effects"
+                    + NL;
+            message += "Press OK when when ready to continue testing" + NL;
+
+            displayInstructionAndWait(message, "Step 6.6.11.d & e", WARNING);
+        }
     }
 
 }


### PR DESCRIPTION
Fix #319 - Add part 06 step 11 and associated unit tests.  Moved the waitForManufacurerInterval up because it is used in enough place to be pulled up.