### PR TITLE
Remove Milestones

### DIFF
--- a/src-test/org/etools/j1939_84/controllers/AbstractPartControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/AbstractPartControllerTest.java
@@ -229,27 +229,6 @@ public class AbstractPartControllerTest {
 
         String partName = Lookup.getPartName(partNumber);
 
-        StringBuilder expectedMilestones = new StringBuilder("Begin Part: " + partName + NL);
-        for (int i = 1; i <= stepControllers.size(); i++) {
-            String stepName = Lookup.getStepName(partNumber, i);
-            expectedMilestones.append("Begin Step: Step ")
-                              .append(partNumber)
-                              .append(".")
-                              .append(i)
-                              .append(". ")
-                              .append(stepName)
-                              .append(NL);
-            expectedMilestones.append("End Step: Step ")
-                              .append(partNumber)
-                              .append(".")
-                              .append(i)
-                              .append(". ")
-                              .append(stepName)
-                              .append(NL);
-        }
-        expectedMilestones.append("End Part: ").append(partName);
-        assertEquals(expectedMilestones.toString(), listener.getMilestones());
-
         StringBuilder expectedMessages = new StringBuilder();
         for (int i = 1; i <= stepControllers.size(); i++) {
             expectedMessages.append(NL)

--- a/src-test/org/etools/j1939_84/controllers/TestResultsListener.java
+++ b/src-test/org/etools/j1939_84/controllers/TestResultsListener.java
@@ -10,8 +10,6 @@ import java.util.List;
 
 import org.etools.j1939_84.model.ActionOutcome;
 import org.etools.j1939_84.model.Outcome;
-import org.etools.j1939_84.model.PartResult;
-import org.etools.j1939_84.model.StepResult;
 import org.etools.j1939_84.model.VehicleInformation;
 import org.etools.j1939_84.model.VehicleInformationListener;
 
@@ -23,7 +21,6 @@ import org.etools.j1939_84.model.VehicleInformationListener;
 public class TestResultsListener implements ResultsListener {
 
     private final List<String> messages = new ArrayList<>();
-    private final List<String> milestones = new ArrayList<>();
     private final ResultsListener mockListener;
     private final List<String> results = new ArrayList<>();
     private final List<ActionOutcome> outcomes = new ArrayList<>();
@@ -44,25 +41,6 @@ public class TestResultsListener implements ResultsListener {
         mockListener.addOutcome(partNumber, stepNumber, outcome, message);
     }
 
-    @Override
-    public void beginPart(PartResult partResult) {
-        milestones.add("Begin Part: " + partResult);
-    }
-
-    @Override
-    public void beginStep(StepResult stepResult) {
-        milestones.add("Begin Step: " + stepResult);
-    }
-
-    @Override
-    public void endPart(PartResult partResult) {
-        milestones.add("End Part: " + partResult);
-    }
-
-    @Override
-    public void endStep(StepResult stepResult) {
-        milestones.add("End Step: " + stepResult);
-    }
 
     @Override
     public void onComplete(boolean success) {
@@ -118,14 +96,6 @@ public class TestResultsListener implements ResultsListener {
 
     public String getMessages() {
         return String.join(NL, messages);
-    }
-
-    /**
-     * @deprecated TODO remove this method; it's not useful
-     */
-    @Deprecated
-    public String getMilestones() {
-        return String.join(NL, milestones);
     }
 
     public String getResults() {

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step08ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step08ControllerTest.java
@@ -203,7 +203,6 @@ public class Part01Step08ControllerTest extends AbstractControllerTest {
                                         "6.1.8.2.a - Minimum expected SPNs are not supported. Not Supported SPNs: 3054");
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -268,7 +267,6 @@ public class Part01Step08ControllerTest extends AbstractControllerTest {
                                         "6.1.8.2.a - Minimum expected SPNs are not supported. Not Supported SPNs: 3055, 3058, 3064, 5318, 5321, 5322 None of these SPNs are supported: 4364, 4792, 5308");
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step09ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step09ControllerTest.java
@@ -202,7 +202,6 @@ public class Part01Step09ControllerTest extends AbstractControllerTest {
 
         // Verify the documentation was recorded correctly
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("Function 0 module is Engine #1 (0)" + NL, listener.getResults());
     }
 
@@ -245,7 +244,6 @@ public class Part01Step09ControllerTest extends AbstractControllerTest {
 
         // Verify the documentation was recorded correctly
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("Function 0 module is Engine #1 (0)" + NL, listener.getResults());
     }
 
@@ -287,7 +285,6 @@ public class Part01Step09ControllerTest extends AbstractControllerTest {
 
         // Verify the documentation was recorded correctly
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("Function 0 module is Engine #1 (0)" + NL, listener.getResults());
     }
 
@@ -358,7 +355,6 @@ public class Part01Step09ControllerTest extends AbstractControllerTest {
 
         // Verify the documentation was recorded correctly
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("Function 0 module is Engine #1 (0)" + NL, listener.getResults());
     }
 
@@ -398,7 +394,6 @@ public class Part01Step09ControllerTest extends AbstractControllerTest {
 
         // Verify the documentation was recorded correctly
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("Function 0 module is Engine #1 (0)" + NL, listener.getResults());
     }
 
@@ -437,7 +432,6 @@ public class Part01Step09ControllerTest extends AbstractControllerTest {
 
         // Verify the documentation was recorded correctly
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("Function 0 module is Engine #1 (0)" + NL, listener.getResults());
     }
 
@@ -475,7 +469,6 @@ public class Part01Step09ControllerTest extends AbstractControllerTest {
 
         // Verify the documentation was recorded correctly
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("Function 0 module is Engine #1 (0)" + NL, listener.getResults());
     }
 
@@ -513,7 +506,6 @@ public class Part01Step09ControllerTest extends AbstractControllerTest {
 
         // Verify the documentation was recorded correctly
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("Function 0 module is Engine #1 (0)" + NL, listener.getResults());
     }
 
@@ -553,7 +545,6 @@ public class Part01Step09ControllerTest extends AbstractControllerTest {
 
         // Verify the documentation was recorded correctly
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("Function 0 module is Engine #1 (0)" + NL, listener.getResults());
     }
 
@@ -591,7 +582,6 @@ public class Part01Step09ControllerTest extends AbstractControllerTest {
 
         // Verify the documentation was recorded correctly
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("Function 0 module is Engine #1 (0)" + NL, listener.getResults());
     }
 
@@ -627,7 +617,6 @@ public class Part01Step09ControllerTest extends AbstractControllerTest {
 
         // Verify the documentation was recorded correctly
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("Function 0 module is Engine #1 (0)" + NL, listener.getResults());
     }
 
@@ -724,7 +713,6 @@ public class Part01Step09ControllerTest extends AbstractControllerTest {
 
         // Verify the documentation was recorded correctly
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("Function 0 module is Engine #1 (0)" + NL, listener.getResults());
     }
 
@@ -762,7 +750,6 @@ public class Part01Step09ControllerTest extends AbstractControllerTest {
 
         // Verify the documentation was recorded correctly
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("Function 0 module is Engine #1 (0)" + NL, listener.getResults());
     }
 
@@ -800,7 +787,6 @@ public class Part01Step09ControllerTest extends AbstractControllerTest {
 
         // Verify the documentation was recorded correctly
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("Function 0 module is Engine #1 (0)" + NL, listener.getResults());
     }
 }

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step10ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step10ControllerTest.java
@@ -147,7 +147,6 @@ public class Part01Step10ControllerTest extends AbstractControllerTest {
         expectedMessages += "Step 1.10.1.c. Waiting for 2 seconds" + NL;
         expectedMessages += "Step 1.10.1.c. Waiting for 1 seconds";
         assertEquals(expectedMessages, listener.getMessages());
-        assertEquals("", listener.getMilestones());
     }
 
     @Test
@@ -189,7 +188,6 @@ public class Part01Step10ControllerTest extends AbstractControllerTest {
         expectedMessages += "Step 1.10.1.c. Waiting for 2 seconds" + NL;
         expectedMessages += "Step 1.10.1.c. Waiting for 1 seconds";
         assertEquals(expectedMessages, listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step11ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step11ControllerTest.java
@@ -157,7 +157,6 @@ public class Part01Step11ControllerTest extends AbstractControllerTest {
                                         FAIL,
                                         "6.1.11.4.f - OBD module Cruise Control (17) did not provide a response to Global query and did not provide a NACK for the DS query");
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -219,7 +218,6 @@ public class Part01Step11ControllerTest extends AbstractControllerTest {
                                         "6.1.11.4.f - OBD module Suspension - Drive Axle #1 (21) did not provide a response to Global query and did not provide a NACK for the DS query");
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -273,7 +271,6 @@ public class Part01Step11ControllerTest extends AbstractControllerTest {
                                         "6.1.11.4.f - OBD module Suspension - Drive Axle #1 (21) did not provide a response to Global query and did not provide a NACK for the DS query");
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -327,7 +324,6 @@ public class Part01Step11ControllerTest extends AbstractControllerTest {
                                         "6.1.11.4.f - OBD module Suspension - Drive Axle #1 (21) did not provide a response to Global query and did not provide a NACK for the DS query");
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -371,7 +367,6 @@ public class Part01Step11ControllerTest extends AbstractControllerTest {
         verify(diagnosticMessageModule).requestDM21(any(), eq(21));
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -422,7 +417,6 @@ public class Part01Step11ControllerTest extends AbstractControllerTest {
                                         "6.1.11.4.a - Cruise Control (17) reported distance with MIL on (SPN 3069) is not zero");
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -470,7 +464,6 @@ public class Part01Step11ControllerTest extends AbstractControllerTest {
                                         "6.1.11.4.b - Cruise Control (17) reported distance SCC (SPN 3294) is not zero");
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -521,7 +514,6 @@ public class Part01Step11ControllerTest extends AbstractControllerTest {
                                         "6.1.11.4.d - Cruise Control (17) reported time SCC (SPN 3296) > 1 minute");
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
 
     }
@@ -571,7 +563,6 @@ public class Part01Step11ControllerTest extends AbstractControllerTest {
                                         "6.1.11.4.c - Engine #1 (0) reported time with MIL on (SPN 3295) is not zero");
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step12ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step12ControllerTest.java
@@ -160,7 +160,6 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
         verify(tableA7Validator).validateForCompressionIgnition(any(), any());
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -196,7 +195,6 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
         verify(tableA7Validator).validateForCompressionIgnition(any(), any());
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -229,7 +227,6 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
         verify(tableA7Validator).validateForSparkIgnition(any(), any());
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -273,7 +270,6 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
         verify(tableA7Validator).findDuplicates(any());
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -312,7 +308,6 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
 
         // Verify the documentation was recorded correctly
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -349,7 +344,6 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
         verify(tableA7Validator).validateForSparkIgnition(any(), any());
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -387,7 +381,6 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
         verify(tableA7Validator).validateForSparkIgnition(any(), any());
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -425,7 +418,6 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
         verify(tableA7Validator).validateForSparkIgnition(any(), any());
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -440,7 +432,6 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
         verify(tableA7Validator).validateForCompressionIgnition(any(), any());
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -474,7 +465,6 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
         verify(tableA7Validator).validateForSparkIgnition(any(), any());
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
         assertEquals(List.of(), listener.getOutcomes());
     }
@@ -526,7 +516,6 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
 
         // Verify the documentation was recorded correctly
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -561,7 +550,6 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
         verify(tableA7Validator).validateForSparkIgnition(any(), any());
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 }

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step13ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step13ControllerTest.java
@@ -200,7 +200,6 @@ public class Part01Step13ControllerTest extends AbstractControllerTest {
         verify(sectionA6Validator).verify(any(), eq(PART_NUMBER), eq(STEP_NUMBER), eq(globalRequestResponse));
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         String expectedVehicleComposite = NL + "Vehicle Composite of DM5:" + NL +
                 "    A/C system refrigerant     not supported,     complete" + NL +
                 "    Boost pressure control sys     supported, not complete" + NL +
@@ -286,7 +285,6 @@ public class Part01Step13ControllerTest extends AbstractControllerTest {
         verify(sectionA6Validator).verify(any(), eq(PART_NUMBER), eq(STEP_NUMBER), eq(globalRequestResponse));
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -442,7 +440,6 @@ public class Part01Step13ControllerTest extends AbstractControllerTest {
         verify(sectionA6Validator).verify(any(), eq(PART_NUMBER), eq(STEP_NUMBER), eq(globalResponse));
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         String expectedVehicleComposite = NL + "Vehicle Composite of DM5:" + NL +
                 "    A/C system refrigerant     not supported,     complete" + NL +
                 "    Boost pressure control sys     supported, not complete" + NL +

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step16ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step16ControllerTest.java
@@ -232,7 +232,8 @@ public class Part01Step16ControllerTest extends AbstractControllerTest {
                                         "6.1.16.2.c - Non-OBD ECU Engine #1 (0) did not report MIL off or not supported");
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getResults());
+        String expected = "";
+        assertEquals(expected, listener.getResults());
     }
 
     @Test

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step16ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step16ControllerTest.java
@@ -232,8 +232,7 @@ public class Part01Step16ControllerTest extends AbstractControllerTest {
                                         "6.1.16.2.c - Non-OBD ECU Engine #1 (0) did not report MIL off or not supported");
 
         assertEquals("", listener.getMessages());
-        String expected = "";
-        assertEquals(expected, listener.getResults());
+        assertEquals("", listener.getResults());
     }
 
     @Test

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step17ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step17ControllerTest.java
@@ -142,7 +142,6 @@ public class Part01Step17ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
     }
 
     @Test
@@ -281,7 +280,6 @@ public class Part01Step17ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
     }
 
 }

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step18ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step18ControllerTest.java
@@ -309,7 +309,6 @@ public class Part01Step18ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -362,7 +361,6 @@ public class Part01Step18ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
     }
 
 }

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step19ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step19ControllerTest.java
@@ -154,7 +154,6 @@ public class Part01Step19ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
     }
 
     @Test
@@ -304,7 +303,6 @@ public class Part01Step19ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -353,7 +351,6 @@ public class Part01Step19ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
     }
 
 }

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step20ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step20ControllerTest.java
@@ -155,7 +155,6 @@ public class Part01Step20ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
     }
 
     @Test
@@ -305,7 +304,6 @@ public class Part01Step20ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
@@ -354,7 +352,6 @@ public class Part01Step20ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
     }
 
 }

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step21ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step21ControllerTest.java
@@ -154,7 +154,6 @@ public class Part01Step21ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
     }
 
     @Test
@@ -299,7 +298,6 @@ public class Part01Step21ControllerTest extends AbstractControllerTest {
                                         "6.1.21.4.b - OBD module Transmission #1 (3) did not provide a response to Global query and did not provide a NACK for the DS query");
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
     }
 
     @Test
@@ -398,7 +396,6 @@ public class Part01Step21ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
     }
 
     @Test
@@ -478,7 +475,6 @@ public class Part01Step21ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
     }
 
     @Test
@@ -513,7 +509,6 @@ public class Part01Step21ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
     }
 
     @Test
@@ -564,7 +559,6 @@ public class Part01Step21ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
     }
 
 }

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step23ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step23ControllerTest.java
@@ -143,7 +143,6 @@ public class Part01Step23ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
     }
 
     /**
@@ -213,6 +212,5 @@ public class Part01Step23ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
     }
 }

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step26ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step26ControllerTest.java
@@ -336,8 +336,6 @@ public class Part01Step26ControllerTest extends AbstractControllerTest {
         expectedMsg += "Global Request for PGN 66666" + NL;
         expectedMsg += "End Part 1 Step 26";
         assertEquals(expectedMsg, listener.getMessages());
-
-        assertEquals("", listener.getMilestones());
     }
 
     @Ignore("Fix once Step 26 is accepted")
@@ -416,8 +414,6 @@ public class Part01Step26ControllerTest extends AbstractControllerTest {
         expectedMsg += "DS Request for 44444 to Engine #1 (0)" + NL;
         expectedMsg += "End Part 1 Step 26";
         assertEquals(expectedMsg, listener.getMessages());
-
-        assertEquals("", listener.getMilestones());
     }
 
     @Test

--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step27ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step27ControllerTest.java
@@ -186,15 +186,10 @@ public class Part01Step27ControllerTest extends AbstractControllerTest {
         expectedMessages.append(NL).append("User cancelled testing at Part 1 Step 27");
         assertEquals(expectedMessages.toString(), listener.getMessages());
 
-        String expectedMilestones = "";
-        assertEquals(expectedMilestones, listener.getMilestones());
-
         String expectedResults = "";
         expectedResults += "Initial Engine Speed = 0.0 RPMs" + NL;
         expectedResults += "Final Engine Speed = 0.0 RPMs" + NL;
         assertEquals(expectedResults, listener.getResults());
-
-        assertEquals("", listener.getMilestones());
     }
 
     @Test
@@ -272,12 +267,10 @@ public class Part01Step27ControllerTest extends AbstractControllerTest {
         }
         assertEquals(expectedMessages.toString(), listener.getMessages());
 
-        assertEquals("", listener.getMilestones());
         String expected = "";
         expected += "Initial Engine Speed = 0.0 RPMs" + NL;
         expected += "Final Engine Speed = 0.0 RPMs" + NL;
         assertEquals(expected, listener.getResults());
-        assertEquals("", listener.getMilestones());
     }
 
     // FIXME - this needs to be fixed when we figure out how to throw the InterruptedException.
@@ -340,8 +333,6 @@ public class Part01Step27ControllerTest extends AbstractControllerTest {
         String expectedResults = "Initial Engine Speed = 0.0 RPMs" + NL;
         expectedResults += "Final Engine Speed = 0.0 RPMs" + NL;
         assertEquals(expectedResults, listener.getResults());
-
-        assertEquals("", listener.getMilestones());
     }
 
 }

--- a/src-test/org/etools/j1939_84/controllers/part01/SectionA5VerifierTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/SectionA5VerifierTest.java
@@ -92,7 +92,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // assertTrue(instance.verifyDM12(listener));
     //
     // assertEquals("PASS: Section A.5 Step 1.b DM12 Verification", listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(diagnosticMessageModule).setJ1939(j1939);
@@ -124,7 +123,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // NL +
     // "MIL status is : fast flash.";
     // assertEquals(expectedMessages, listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(diagnosticMessageModule).setJ1939(j1939);
@@ -160,7 +158,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // NL +
     // "MIL status is : fast flash.";
     // assertEquals(expectedMessages, listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(diagnosticMessageModule).setJ1939(j1939);
@@ -192,7 +189,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // listener));
     //
     // assertEquals("PASS: Section A.5 Step 7.a DM20 Verification", listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(diagnosticMessageModule).setJ1939(j1939);
@@ -228,7 +224,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // + "Previous Monitor Performance Ratio (DM20):" + NL +
     // "Post Monitor Performance Ratio (DM20):" + NL + "dm20Packet.toString()" + NL;
     // assertEquals(expectedMessages, listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(diagnosticMessageModule).setJ1939(j1939);
@@ -258,7 +253,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // assertTrue(instance.verifyDM21(listener));
     //
     // assertEquals("PASS: Section A.5 Step 3.b & 5.b DM21 Verification", listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(diagnosticMessageModule).setJ1939(j1939);
@@ -295,7 +289,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // NL + "0.0 km(s) since DTC code clear sent" + NL +
     // "0.0 minute(s) since the DTC code clear sent";
     // assertEquals(expectedMessages, listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(diagnosticMessageModule).setJ1939(j1939);
@@ -332,7 +325,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // NL + "0.0 km(s) since DTC code clear sent" + NL +
     // "0.0 minute(s) since the DTC code clear sent";
     // assertEquals(expectedMessages, listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(diagnosticMessageModule).setJ1939(j1939);
@@ -369,7 +361,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // NL + "0.0 km(s) since DTC code clear sent" + NL +
     // "15.0 minute(s) since the DTC code clear sent";
     // assertEquals(expectedMessages, listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(diagnosticMessageModule).setJ1939(j1939);
@@ -403,7 +394,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // assertTrue(instance.verifyDM23(listener));
     //
     // assertEquals("PASS: Section A.5 Step 1.c DM23 Verification", listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(diagnosticMessageModule).setJ1939(j1939);
@@ -440,7 +430,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // + "Module with source address 0, reported 0 DTCs." + NL +
     // "MIL status is : on.";
     // assertEquals(expectedMessages, listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(diagnosticMessageModule).setJ1939(j1939);
@@ -491,7 +480,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // assertTrue(instance.verifyDM25(listener, obdModuleAddresses));
     //
     // assertEquals("PASS: Section A.5 Step 2.a DM25 Verification", listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(diagnosticMessageModule).setJ1939(j1939);
@@ -550,7 +538,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // "Module with source address 0, has 1 supported SPNs" + NL +
     // "Module with source address 33, has 1 supported SPNs";
     // assertEquals(expectedMessages, listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(diagnosticMessageModule).setJ1939(j1939);
@@ -609,7 +596,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // "Module with source address 23, has 1 supported SPNs" + NL +
     // "Module with source address 33, has 1 supported SPNs";
     // assertEquals(expectedMessages, listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(diagnosticMessageModule).setJ1939(j1939);
@@ -642,7 +628,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // assertTrue(instance.verifyDM26(listener));
     //
     // assertEquals("PASS: Section A.5 Step 5.a DM26 Verification", listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(diagnosticMessageModule).setJ1939(j1939);
@@ -677,7 +662,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // NL +
     // "Modules with source address 0, reported 2 warm-ups since code clear";
     // assertEquals(expectedMessages, listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(diagnosticMessageModule).setJ1939(j1939);
@@ -705,7 +689,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // listener));
     //
     // assertEquals("PASS: Section A.5 Step 8.a DM28 Verification", listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(diagnosticMessageModule).setJ1939(j1939);
@@ -767,7 +750,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // "DTC 157:7 - Engine Fuel 1 Injector Metering Rail 1 Pressure, Mechanical System Not Responding Or Out Of
     // Adjustment - 1 times";
     // assertEquals(expectedMessages, listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(diagnosticMessageModule).setJ1939(j1939);
@@ -811,7 +793,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // assertTrue(instance.verifyDM29(listener));
     //
     // assertEquals("PASS: Section A.5 Step 1.d DM29 Verification", listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(diagnosticMessageModule).setJ1939(j1939);
@@ -855,7 +836,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // String expectedMessages = "Section A.5 verification failed during DM29 check done at table step 1.d" + NL +
     // "Modules with source address 0, dm29Packet.toString() ";
     // assertEquals(expectedMessages, listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(diagnosticMessageModule).setJ1939(j1939);
@@ -902,7 +882,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // String expectedMessages = "Section A.5 verification failed during DM29 check done at table step 1.d" + NL +
     // "Modules with source address 0, dm29Packet.toString() ";
     // assertEquals(expectedMessages, listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(diagnosticMessageModule).setJ1939(j1939);
@@ -948,7 +927,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // String expectedMessages = "Section A.5 verification failed during DM29 check done at table step 1.d" + NL +
     // "Modules with source address 0, dm29Packet.toString() ";
     // assertEquals(expectedMessages, listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(diagnosticMessageModule).setJ1939(j1939);
@@ -976,7 +954,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // assertTrue(instance.verifyDM31(listener));
     //
     // assertEquals("PASS: Section A.5 Step 3.a DM31 Verification", listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(diagnosticMessageModule).setJ1939(j1939);
@@ -1012,7 +989,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // String expectedMessages = "Section A.5 verification failed during DM31 check done at table step 3.a" + NL +
     // "Modules with source address 0, is reporting 1 with DTC lamp status(es) causing MIL on.";
     // assertEquals(expectedMessages, listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(diagnosticMessageModule).setJ1939(j1939);
@@ -1085,7 +1061,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // assertTrue(instance.verifyDM33(dm33Packets, listener, obdModuleAddresses));
     //
     // assertEquals("PASS: Section A.5 Step 9.a DM33 Verification", listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(diagnosticMessageModule).setJ1939(j1939);
@@ -1170,7 +1145,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // expectedMessages += " dm33Packet17.toString()" + NL;
     // expectedMessages += " dm33Packet21.toString()";
     // assertEquals(expectedMessages, listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(diagnosticMessageModule).setJ1939(j1939);
@@ -1255,7 +1229,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // expectedMessages += "}" + NL + NL;
     // expectedMessages += " dm33Packet17.toString()";
     // assertEquals(expectedMessages, listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(diagnosticMessageModule).setJ1939(j1939);
@@ -1293,7 +1266,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // NL +
     // "PASS: Section A.5 Step 4.a DM5 Verification";
     // assertEquals(expectedMessages, listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(diagnosticMessageModule).setJ1939(j1939);
@@ -1338,7 +1310,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // "Section A.5 verification failed during DM5 check done at table step 4.a" + NL +
     // "Module address 0 :" + NL + "dm5Packet.toString()";
     // assertEquals(expectedMessages, listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(diagnosticMessageModule).setJ1939(j1939);
@@ -1381,7 +1352,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // "Modules with source address 0, reported 2 active DTCs and 0 previously active DTCs" + NL +
     // "PASS: Section A.5 Step 4.a DM5 Verification";
     // assertEquals(expectedMessages, listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(diagnosticMessageModule).setJ1939(j1939);
@@ -1414,7 +1384,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // assertTrue(instance.verifyDM6(listener));
     //
     // assertEquals("PASS: Section A.5 Step 1.a DM6 Verfication", listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(diagnosticMessageModule).setJ1939(j1939);
@@ -1452,7 +1421,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // "Modules with source address 0, reported 1 DTCs." + NL +
     // "MIL status is : slow flash.";
     // assertEquals(expectedMessages, listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(diagnosticMessageModule).setJ1939(j1939);
@@ -1522,7 +1490,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // assertTrue(instance.verifyDM7DM30(listener, obdModuleAddresses));
     //
     // assertEquals("PASS: Section A.5 Step 6.a DM7/DM30 Verification", listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(dataRepository).getObdModule(eq(0x00));
@@ -1609,7 +1576,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // NL + "]" + NL + "source address 0 are : [" + NL +
     // " TestResult failed and the value returned was : 85" + NL + "]";
     // assertEquals(expectedMessages, listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(dataRepository).getObdModule(eq(0x00));
@@ -1648,7 +1614,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // "PASS: Section A.5 Step 9.b Cumulative engine runtime (PGN 65253 (SPN 247)) and engine idle time (PGN 65244 (SPN
     // 235)) Verification",
     // listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(diagnosticMessageModule).setJ1939(j1939);
@@ -1715,7 +1680,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // expected += " SPN 249, Engine Total Revolutions: 287454020000.000000 r" + NL;
     // expected += NL;
     // assertEquals(expected, listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(diagnosticMessageModule).setJ1939(j1939);
@@ -1785,7 +1749,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // expected += " SPN 249, Engine Total Revolutions: 287454020000.000000 r" + NL;
     // expected += NL;
     // assertEquals(expected, listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(diagnosticMessageModule).setJ1939(j1939);
@@ -2176,7 +2139,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // " Engine Hours from Engine #1 (0): 210,554,060.75 hours" +
     // NL;
     // assertEquals(expectedMessages, listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(dataRepository).getObdModuleAddresses();
@@ -2576,7 +2538,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // " EMPTY" +
     // NL;
     // assertEquals(expectedMessages, listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(dataRepository).getObdModuleAddresses();
@@ -2846,7 +2807,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // assertEquals(
     // expectedMessages,
     // listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(dataRepository).getObdModuleAddresses();
@@ -3104,7 +3064,6 @@ public class SectionA5VerifierTest extends AbstractControllerTest {
     // assertEquals(
     // expectedMessages,
     // listener.getMessages());
-    // assertEquals("", listener.getMilestones());
     // assertEquals("", listener.getResults());
     //
     // verify(dataRepository).getObdModuleAddresses();

--- a/src-test/org/etools/j1939_84/controllers/part01/SectionA6ValidatorTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/SectionA6ValidatorTest.java
@@ -137,7 +137,6 @@ public class SectionA6ValidatorTest {
         verify(tableA6Validator, times(3)).verify(any(), any(), eq(PART_NUMBER), eq(STEP_NUMBER));
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -173,7 +172,6 @@ public class SectionA6ValidatorTest {
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL, expectedMessage1a.toString());
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -258,7 +256,6 @@ public class SectionA6ValidatorTest {
         verify(tableA6Validator, times(4)).verify(any(), any(), eq(PART_NUMBER), eq(STEP_NUMBER));
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -321,7 +318,6 @@ public class SectionA6ValidatorTest {
         verify(tableA6Validator, times(3)).verify(any(), any(), eq(PART_NUMBER), eq(STEP_NUMBER));
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -453,7 +449,6 @@ public class SectionA6ValidatorTest {
         verify(tableA6Validator, times(2)).verify(any(), any(), eq(PART_NUMBER), eq(STEP_NUMBER));
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 

--- a/src-test/org/etools/j1939_84/controllers/part01/TableA6ValidatorTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/TableA6ValidatorTest.java
@@ -365,7 +365,6 @@ public class TableA6ValidatorTest {
         assertTrue(instance.verify(listener, packet1, PART_NUMBER, STEP_NUMBER));
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
 
         verify(dataRepository, atLeast(1)).getVehicleInformation();
@@ -502,7 +501,6 @@ public class TableA6ValidatorTest {
         assertFalse(instance.verify(listener, packet1, PART_NUMBER, STEP_NUMBER));
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
 
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL, "TableA6 A/C system refrigerant verification");
@@ -632,7 +630,6 @@ public class TableA6ValidatorTest {
         assertFalse(instance.verify(listener, packet1, PART_NUMBER, STEP_NUMBER));
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
 
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL, "TableA6 A/C system refrigerant verification");
@@ -771,7 +768,6 @@ public class TableA6ValidatorTest {
         assertTrue(instance.verify(listener, packet1, PART_NUMBER, STEP_NUMBER));
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
 
         verify(dataRepository, atLeast(1)).getVehicleInformation();
@@ -903,7 +899,6 @@ public class TableA6ValidatorTest {
         assertFalse(instance.verify(listener, packet1, PART_NUMBER, STEP_NUMBER));
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
 
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL, "TableA6 A/C system refrigerant verification");

--- a/src-test/org/etools/j1939_84/controllers/part02/Part02Step02ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part02/Part02Step02ControllerTest.java
@@ -213,7 +213,6 @@ public class Part02Step02ControllerTest extends AbstractControllerTest {
         verify(sectionA6Validator).verify(any(), eq(PART_NUMBER), eq(STEP_NUMBER), eq(globalRequestResponse));
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -311,7 +310,6 @@ public class Part02Step02ControllerTest extends AbstractControllerTest {
         verify(sectionA6Validator).verify(any(), eq(PART_NUMBER), eq(STEP_NUMBER), eq(globalRequestResponse));
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         String expectedResults = NL + "Vehicle Composite of DM5:" + NL +
                 "    A/C system refrigerant     not supported,     complete" + NL +
@@ -410,7 +408,6 @@ public class Part02Step02ControllerTest extends AbstractControllerTest {
         verify(sectionA6Validator).verify(any(), eq(PART_NUMBER), eq(STEP_NUMBER), eq(globalRequestResponse));
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -499,7 +496,6 @@ public class Part02Step02ControllerTest extends AbstractControllerTest {
         verify(sectionA6Validator).verify(any(), eq(PART_NUMBER), eq(STEP_NUMBER), eq(globalRequestResponse));
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         String expectedResults = NL + "Vehicle Composite of DM5:" + NL +
                 "    A/C system refrigerant     not supported,     complete" + NL +
@@ -591,7 +587,6 @@ public class Part02Step02ControllerTest extends AbstractControllerTest {
         verify(sectionA6Validator).verify(any(), eq(PART_NUMBER), eq(STEP_NUMBER), eq(globalRequestResponse));
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         String expectedVehicleComposite = NL + "Vehicle Composite of DM5:" + NL +
                 "    A/C system refrigerant     not supported,     complete" + NL +
                 "    Boost pressure control sys     supported, not complete" + NL +

--- a/src-test/org/etools/j1939_84/controllers/part02/Part02Step07ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part02/Part02Step07ControllerTest.java
@@ -229,7 +229,6 @@ public class Part02Step07ControllerTest extends AbstractControllerTest {
 
         // Verify the documentation was recorded correctly
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -360,7 +359,6 @@ public class Part02Step07ControllerTest extends AbstractControllerTest {
 
         // Verify the documentation was recorded correctly
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -457,7 +455,6 @@ public class Part02Step07ControllerTest extends AbstractControllerTest {
 
         // Verify the documentation was recorded correctly
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -556,7 +553,6 @@ public class Part02Step07ControllerTest extends AbstractControllerTest {
 
         // Verify the documentation was recorded correctly
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -666,7 +662,6 @@ public class Part02Step07ControllerTest extends AbstractControllerTest {
 
         // Verify the documentation was recorded correctly
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
 
     }
@@ -768,7 +763,6 @@ public class Part02Step07ControllerTest extends AbstractControllerTest {
 
         // Verify the documentation was recorded correctly
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -868,7 +862,6 @@ public class Part02Step07ControllerTest extends AbstractControllerTest {
 
         // Verify the documentation was recorded correctly
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -975,7 +968,6 @@ public class Part02Step07ControllerTest extends AbstractControllerTest {
 
         // Verify the documentation was recorded correctly
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 }

--- a/src-test/org/etools/j1939_84/controllers/part02/Part02Step09ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part02/Part02Step09ControllerTest.java
@@ -128,7 +128,6 @@ public class Part02Step09ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
     }
 
     @Test
@@ -152,7 +151,6 @@ public class Part02Step09ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
     }
 
     @Test
@@ -183,7 +181,6 @@ public class Part02Step09ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
     }
 
     @Test
@@ -211,7 +208,6 @@ public class Part02Step09ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
     }
 
     @Test
@@ -239,7 +235,6 @@ public class Part02Step09ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
     }
 
     @Test
@@ -264,7 +259,6 @@ public class Part02Step09ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
     }
 
     @Test
@@ -292,7 +286,6 @@ public class Part02Step09ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
     }
 
     @Test
@@ -320,6 +313,5 @@ public class Part02Step09ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
     }
 }

--- a/src-test/org/etools/j1939_84/controllers/part02/Part02Step13ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part02/Part02Step13ControllerTest.java
@@ -150,7 +150,6 @@ public class Part02Step13ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
     }
 
     /**
@@ -179,7 +178,6 @@ public class Part02Step13ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
     }
 
     /**
@@ -242,7 +240,6 @@ public class Part02Step13ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
     }
 
     /**
@@ -313,6 +310,5 @@ public class Part02Step13ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
     }
 }

--- a/src-test/org/etools/j1939_84/controllers/part02/Part02Step16ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part02/Part02Step16ControllerTest.java
@@ -151,7 +151,6 @@ public class Part02Step16ControllerTest extends AbstractControllerTest {
 
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
     }
 
@@ -171,7 +170,6 @@ public class Part02Step16ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(mockListener).addOutcome(PART,
                                         STEP,
@@ -200,7 +198,6 @@ public class Part02Step16ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(mockListener).addOutcome(PART,
                                         STEP,
@@ -249,7 +246,6 @@ public class Part02Step16ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(mockListener).addOutcome(PART,
                                         STEP,
@@ -281,7 +277,6 @@ public class Part02Step16ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(mockListener).addOutcome(PART,
                                         STEP,

--- a/src-test/org/etools/j1939_84/controllers/part02/Part02Step18ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part02/Part02Step18ControllerTest.java
@@ -176,15 +176,10 @@ public class Part02Step18ControllerTest extends AbstractControllerTest {
         expectedMessages += "User cancelled testing at Part 2 Step 18";
         assertEquals(expectedMessages, listener.getMessages());
 
-        String expectedMilestones = "";
-        assertEquals(expectedMilestones, listener.getMilestones());
-
         String expectedResults = "";
         expectedResults += "Initial Engine Speed = 0.0 RPMs" + NL;
         expectedResults += "Final Engine Speed = 0.0 RPMs" + NL;
         assertEquals(expectedResults, listener.getResults());
-
-        assertEquals("", listener.getMilestones());
     }
 
     @Test
@@ -257,14 +252,10 @@ public class Part02Step18ControllerTest extends AbstractControllerTest {
         expectedMessages += "User cancelled testing at Part 2 Step 18";
         assertEquals(expectedMessages, listener.getMessages());
 
-        assertEquals("", listener.getMilestones());
-
         String expectedResults = "";
         expectedResults += "Initial Engine Speed = 0.0 RPMs" + NL;
         expectedResults += "Final Engine Speed = 0.0 RPMs" + NL;
         assertEquals(expectedResults, listener.getResults());
-
-        assertEquals("", listener.getMilestones());
     }
 
 }

--- a/src-test/org/etools/j1939_84/controllers/part03/Part03Step02ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part03/Part03Step02ControllerTest.java
@@ -146,8 +146,6 @@ public class Part03Step02ControllerTest extends AbstractControllerTest {
         String expectedMessages = "Requesting DM6 Attempt 1";
         assertEquals(expectedMessages, listener.getMessages());
 
-        assertEquals("", listener.getMilestones());
-
         String expectedResults = "" + NL;
         expectedResults += "Attempt 1" + NL;
         assertEquals(expectedResults, listener.getResults());
@@ -185,8 +183,6 @@ public class Part03Step02ControllerTest extends AbstractControllerTest {
         expectedMessages.append("Requesting DM6 Attempt 1");
         assertEquals(expectedMessages.toString(), listener.getMessages());
 
-        assertEquals("", listener.getMilestones());
-
         StringBuilder expectedResults = new StringBuilder();
         for (int i = 1; i <= 300; i++) {
             expectedResults.append(NL).append("Attempt ").append(i).append(NL);
@@ -215,8 +211,6 @@ public class Part03Step02ControllerTest extends AbstractControllerTest {
 
         String expectedMessages = "Requesting DM6 Attempt 1";
         assertEquals(expectedMessages, listener.getMessages());
-
-        assertEquals("", listener.getMilestones());
 
         String expectedResults = "" + NL;
         expectedResults += "Attempt 1" + NL;
@@ -248,8 +242,6 @@ public class Part03Step02ControllerTest extends AbstractControllerTest {
         String expectedMessages = "Requesting DM6 Attempt 1";
         assertEquals(expectedMessages, listener.getMessages());
 
-        assertEquals("", listener.getMilestones());
-
         String expectedResults = "" + NL;
         expectedResults += "Attempt 1" + NL;
         assertEquals(expectedResults, listener.getResults());
@@ -277,8 +269,6 @@ public class Part03Step02ControllerTest extends AbstractControllerTest {
 
         String expectedMessages = "Requesting DM6 Attempt 1";
         assertEquals(expectedMessages, listener.getMessages());
-
-        assertEquals("", listener.getMilestones());
 
         String expectedResults = "" + NL;
         expectedResults += "Attempt 1" + NL;
@@ -309,8 +299,6 @@ public class Part03Step02ControllerTest extends AbstractControllerTest {
         String expectedMessages = "Requesting DM6 Attempt 1";
         assertEquals(expectedMessages, listener.getMessages());
 
-        assertEquals("", listener.getMilestones());
-
         String expectedResults = "" + NL;
         expectedResults += "Attempt 1" + NL;
         assertEquals(expectedResults, listener.getResults());
@@ -340,8 +328,6 @@ public class Part03Step02ControllerTest extends AbstractControllerTest {
 
         String expectedMessages = "Requesting DM6 Attempt 1";
         assertEquals(expectedMessages, listener.getMessages());
-
-        assertEquals("", listener.getMilestones());
 
         String expectedResults = "" + NL;
         expectedResults += "Attempt 1" + NL;

--- a/src-test/org/etools/j1939_84/controllers/part03/Part03Step04ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part03/Part03Step04ControllerTest.java
@@ -489,7 +489,6 @@ public class Part03Step04ControllerTest extends AbstractControllerTest {
         runTest();
 
         assertEquals("", listener.getMessages());
-
         assertEquals("", listener.getResults());
 
         verify(diagnosticMessageModule).requestDM29(any());

--- a/src-test/org/etools/j1939_84/controllers/part03/Part03Step04ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part03/Part03Step04ControllerTest.java
@@ -489,6 +489,7 @@ public class Part03Step04ControllerTest extends AbstractControllerTest {
         runTest();
 
         assertEquals("", listener.getMessages());
+
         assertEquals("", listener.getResults());
 
         verify(diagnosticMessageModule).requestDM29(any());

--- a/src-test/org/etools/j1939_84/controllers/part03/Part03Step06ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part03/Part03Step06ControllerTest.java
@@ -147,7 +147,6 @@ public class Part03Step06ControllerTest extends AbstractControllerTest {
         verify(diagnosticMessageModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -170,7 +169,6 @@ public class Part03Step06ControllerTest extends AbstractControllerTest {
                                         "A.8 - Alternate coding for off (0b00, 0b00) has been accepted");
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -183,7 +181,6 @@ public class Part03Step06ControllerTest extends AbstractControllerTest {
         verify(diagnosticMessageModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
 
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL, "6.3.6.2.a - No OBD ECU supports DM1");
@@ -200,7 +197,6 @@ public class Part03Step06ControllerTest extends AbstractControllerTest {
         verify(diagnosticMessageModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
 
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL, "6.3.6.2.a - No OBD ECU supports DM1");
@@ -221,7 +217,6 @@ public class Part03Step06ControllerTest extends AbstractControllerTest {
         verify(diagnosticMessageModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
 
         verify(mockListener).addOutcome(PART_NUMBER,

--- a/src-test/org/etools/j1939_84/controllers/part03/Part03Step07ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part03/Part03Step07ControllerTest.java
@@ -155,7 +155,6 @@ public class Part03Step07ControllerTest extends AbstractControllerTest {
         verify(diagnosticMessageModule).requestDM2(any(), eq(1));
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -179,7 +178,6 @@ public class Part03Step07ControllerTest extends AbstractControllerTest {
         verify(diagnosticMessageModule).requestDM2(any(), eq(1));
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
 
         verify(mockListener).addOutcome(PART_NUMBER,
@@ -203,7 +201,6 @@ public class Part03Step07ControllerTest extends AbstractControllerTest {
         verify(diagnosticMessageModule).requestDM2(any(), eq(0));
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
 
         verify(mockListener).addOutcome(PART_NUMBER,
@@ -226,7 +223,6 @@ public class Part03Step07ControllerTest extends AbstractControllerTest {
         verify(diagnosticMessageModule).requestDM2(any(), eq(0));
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
 
         verify(mockListener).addOutcome(PART_NUMBER,
@@ -245,7 +241,6 @@ public class Part03Step07ControllerTest extends AbstractControllerTest {
         verify(diagnosticMessageModule).requestDM2(any());
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
 
         verify(mockListener).addOutcome(PART_NUMBER,
@@ -270,7 +265,6 @@ public class Part03Step07ControllerTest extends AbstractControllerTest {
         verify(diagnosticMessageModule).requestDM2(any(), eq(0));
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
 
         verify(mockListener).addOutcome(PART_NUMBER,

--- a/src-test/org/etools/j1939_84/controllers/part03/Part03Step15ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part03/Part03Step15ControllerTest.java
@@ -144,7 +144,6 @@ public class Part03Step15ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(diagnosticMessageModule).requestDM21(any(), eq(0));
 
@@ -174,7 +173,7 @@ public class Part03Step15ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
+
 
         verify(diagnosticMessageModule).requestDM21(any(), eq(0));
         verify(diagnosticMessageModule).requestDM21(any(), eq(1));
@@ -212,7 +211,7 @@ public class Part03Step15ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
+
 
         verify(diagnosticMessageModule).requestDM21(any(), eq(0));
         verify(diagnosticMessageModule).requestDM21(any(), eq(1));

--- a/src-test/org/etools/j1939_84/controllers/part03/Part03Step16ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part03/Part03Step16ControllerTest.java
@@ -186,15 +186,10 @@ public class Part03Step16ControllerTest extends AbstractControllerTest {
         expectedMessages += "User cancelled testing at Part 3 Step 16";
         assertEquals(expectedMessages, listener.getMessages());
 
-        String expectedMilestones = "";
-        assertEquals(expectedMilestones, listener.getMilestones());
-
         String expectedResults = "";
         expectedResults += "Initial Engine Speed = 0.0 RPMs" + NL;
         expectedResults += "Final Engine Speed = 0.0 RPMs" + NL;
         assertEquals(expectedResults, listener.getResults());
-
-        assertEquals("", listener.getMilestones());
     }
 
     @Test
@@ -250,11 +245,9 @@ public class Part03Step16ControllerTest extends AbstractControllerTest {
         expectedMessages += "Waiting for manufacturer's recommended interval with the key in off position";
         assertEquals(expectedMessages, listener.getMessages());
 
-        assertEquals("", listener.getMilestones());
         String expected = "Initial Engine Speed = 0.0 RPMs" + NL;
         expected += "Final Engine Speed = 0.0 RPMs" + NL;
         assertEquals(expected, listener.getResults());
-        assertEquals("", listener.getMilestones());
     }
 
     @Test
@@ -309,13 +302,9 @@ public class Part03Step16ControllerTest extends AbstractControllerTest {
         expectedMessages += "User cancelled testing at Part 3 Step 16";
         assertEquals(expectedMessages, listener.getMessages());
 
-        assertEquals("", listener.getMilestones());
-
         String expectedResults = "";
         expectedResults += "Initial Engine Speed = 0.0 RPMs" + NL;
         expectedResults += "Final Engine Speed = 0.0 RPMs" + NL;
         assertEquals(expectedResults, listener.getResults());
-
-        assertEquals("", listener.getMilestones());
     }
 }

--- a/src-test/org/etools/j1939_84/controllers/part05/Part05Step07ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part05/Part05Step07ControllerTest.java
@@ -196,13 +196,11 @@ public class Part05Step07ControllerTest extends AbstractControllerTest {
         expectedMessages += "Waiting manufacturer’s recommended time for Fault A to be detected as passed";
         assertEquals(expectedMessages, listener.getMessages());
 
-        assertEquals("", listener.getMilestones());
         String expected = "Initial Engine Speed = 0.0 RPMs" + NL;
         expected += "Final Engine Speed = 500.0 RPMs" + NL;
         expected += "Initial Engine Speed = 500.0 RPMs" + NL;
         expected += "Final Engine Speed = 500.0 RPMs" + NL;
         assertEquals(expected, listener.getResults());
-        assertEquals("", listener.getMilestones());
 
         verify(engineSpeedModule, atLeastOnce()).getKeyState();
     }
@@ -350,16 +348,12 @@ public class Part05Step07ControllerTest extends AbstractControllerTest {
         expectedMessages += "User cancelled testing at Part 5 Step 7";
         assertEquals(expectedMessages, listener.getMessages());
 
-        assertEquals("", listener.getMilestones());
-
         String expectedResults = "";
         expectedResults += "Initial Engine Speed = 0.0 RPMs" + NL;
         expectedResults += "Final Engine Speed = 0.0 RPMs" + NL;
         expectedResults += "Initial Engine Speed = 0.0 RPMs" + NL;
         expectedResults += "Final Engine Speed = 0.0 RPMs" + NL;
         assertEquals(expectedResults, listener.getResults());
-
-        assertEquals("", listener.getMilestones());
     }
 
 }

--- a/src-test/org/etools/j1939_84/controllers/part06/Part06Step02ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part06/Part06Step02ControllerTest.java
@@ -182,7 +182,6 @@ public class Part06Step02ControllerTest extends AbstractControllerTest {
                                         "6.6.2.2.a - No OBD ECU reported a count of > 0 active DTCs");
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -239,7 +238,6 @@ public class Part06Step02ControllerTest extends AbstractControllerTest {
                                         "6.6.2.2.a - No OBD ECU reported a count of > 0 active DTCs");
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -313,7 +311,6 @@ public class Part06Step02ControllerTest extends AbstractControllerTest {
                                         WARN,
                                         "6.6.2.3.a - ECU module Body Controller (33) reported a count of > 1 active DTCs");
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 

--- a/src-test/org/etools/j1939_84/controllers/part06/Part06Step03ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part06/Part06Step03ControllerTest.java
@@ -141,7 +141,6 @@ public class Part06Step03ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
     }
 
     @Test
@@ -202,7 +201,6 @@ public class Part06Step03ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,

--- a/src-test/org/etools/j1939_84/controllers/part06/Part06Step11ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part06/Part06Step11ControllerTest.java
@@ -211,7 +211,6 @@ public class Part06Step11ControllerTest extends AbstractControllerTest {
         expectedMessages += "Step 6.6.11.g - Waiting manufacturer’s recommended interval with the key in the off position";
         assertEquals(expectedMessages, listener.getMessages());
 
-        assertEquals("", listener.getMilestones());
         String expected = "Initial Engine Speed = 0.0 RPMs" + NL;
         expected += "Final Engine Speed = 500.0 RPMs" + NL;
         expected += "Initial Engine Speed = 500.0 RPMs" + NL;
@@ -220,7 +219,6 @@ public class Part06Step11ControllerTest extends AbstractControllerTest {
         expected += "Final Engine Speed = 500.0 RPMs" + NL;
 
         assertEquals(expected, listener.getResults());
-        assertEquals("", listener.getMilestones());
 
         verify(engineSpeedModule, atLeastOnce()).getKeyState();
     }
@@ -391,8 +389,6 @@ verify(mockListener, atLeastOnce()).addOutcome(PART_NUMBER,
         expectedMessages += "User cancelled testing at Part 6 Step 11";
         assertEquals(expectedMessages, listener.getMessages());
 
-        assertEquals("", listener.getMilestones());
-
         String expectedResults = "";
         expectedResults += "Initial Engine Speed = 0.0 RPMs" + NL;
         expectedResults += "Final Engine Speed = 0.0 RPMs" + NL;
@@ -400,7 +396,5 @@ verify(mockListener, atLeastOnce()).addOutcome(PART_NUMBER,
         expectedResults += "Final Engine Speed = 0.0 RPMs" + NL;
         expectedResults += "Initial Engine Speed = 0.0 RPMs" + NL;
         assertEquals(expectedResults, listener.getResults());
-
-        assertEquals("", listener.getMilestones());
     }
 }

--- a/src-test/org/etools/j1939_84/controllers/part07/Part07Step18ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part07/Part07Step18ControllerTest.java
@@ -251,7 +251,6 @@ public class Part07Step18ControllerTest extends AbstractControllerTest {
         expectedMessages += "Step 6.7.18.1.j - Fault B is a single trip fault; proceeding with part 8 immediately";
         assertEquals(expectedMessages, listener.getMessages());
 
-        assertEquals("", listener.getMilestones());
         String expected = "Initial Engine Speed = 0.0 RPMs" + NL;
         expected += "Final Engine Speed = 0.0 RPMs" + NL;
         expected += "Initial Engine Speed = 0.0 RPMs" + NL;
@@ -264,7 +263,6 @@ public class Part07Step18ControllerTest extends AbstractControllerTest {
         expected += "Final Engine Speed = 500.0 RPMs" + NL;
 
         assertEquals(expected, listener.getResults());
-        assertEquals("", listener.getMilestones());
 
         verify(engineSpeedModule, atLeastOnce()).getKeyState();
     }
@@ -422,7 +420,6 @@ public class Part07Step18ControllerTest extends AbstractControllerTest {
         expectedMessages += "Step 6.7.18.1.n & o - With the ignition key on and engine on proceeding to Part 8";
         assertEquals(expectedMessages, listener.getMessages());
 
-        assertEquals("", listener.getMilestones());
         String expected = "Initial Engine Speed = 0.0 RPMs" + NL;
         expected += "Final Engine Speed = 0.0 RPMs" + NL;
         expected += "Initial Engine Speed = 0.0 RPMs" + NL;
@@ -439,7 +436,6 @@ public class Part07Step18ControllerTest extends AbstractControllerTest {
         expected += "Final Engine Speed = 500.0 RPMs" + NL;
 
         assertEquals(expected, listener.getResults());
-        assertEquals("", listener.getMilestones());
 
         verify(engineSpeedModule, atLeastOnce()).getKeyState();
     }
@@ -571,7 +567,6 @@ public class Part07Step18ControllerTest extends AbstractControllerTest {
         expectedMessages += "Step 6.7.18.1.i - Turn Engine on with the ignition key in the on position";
         assertEquals(expectedMessages, listener.getMessages());
 
-        assertEquals("", listener.getMilestones());
         String expected = "Initial Engine Speed = 0.0 RPMs" + NL;
         expected += "Final Engine Speed = 0.0 RPMs" + NL;
         expected += "Initial Engine Speed = 0.0 RPMs" + NL;
@@ -582,7 +577,6 @@ public class Part07Step18ControllerTest extends AbstractControllerTest {
         expected += "Final Engine Speed = 500.0 RPMs" + NL;
 
         assertEquals(expected, listener.getResults());
-        assertEquals("", listener.getMilestones());
 
         verify(engineSpeedModule, atLeastOnce()).getKeyState();
     }

--- a/src-test/org/etools/j1939_84/controllers/part08/Part08Step16ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part08/Part08Step16ControllerTest.java
@@ -216,8 +216,6 @@ public class Part08Step16ControllerTest extends AbstractControllerTest {
         expectedMessages += "6.8.16.1.e & f - Do Not Start Engine - proceeding with part 9";
         assertEquals(expectedMessages, listener.getMessages());
 
-        assertEquals("", listener.getMilestones());
-
         String expected = "Initial Engine Speed = 0.0 RPMs" + NL;
         expected += "Final Engine Speed = 0.0 RPMs" + NL;
         expected += "Initial Engine Speed = 0.0 RPMs" + NL;
@@ -313,8 +311,6 @@ public class Part08Step16ControllerTest extends AbstractControllerTest {
         expectedMessages += "6.8.16.1.e & f - Do Not Start Engine - proceeding with part 9" + NL;
         expectedMessages += "User cancelled testing at Part 8 Step 16";
         assertEquals(expectedMessages, listener.getMessages());
-
-        assertEquals("", listener.getMilestones());
 
         String expected = "Initial Engine Speed = 0.0 RPMs" + NL;
         expected += "Final Engine Speed = 0.0 RPMs" + NL;

--- a/src-test/org/etools/j1939_84/controllers/part09/Part09Step21ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part09/Part09Step21ControllerTest.java
@@ -173,7 +173,6 @@ public class Part09Step21ControllerTest extends AbstractControllerTest {
                                         "6.9.21.2.a - OBD ECU Body Controller (33) reported > 0 previously active DTCs count");
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -202,7 +201,6 @@ public class Part09Step21ControllerTest extends AbstractControllerTest {
         verify(diagnosticMessageModule).requestDM5(any());
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 

--- a/src-test/org/etools/j1939_84/controllers/part09/Part09Step22ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part09/Part09Step22ControllerTest.java
@@ -158,7 +158,6 @@ public class Part09Step22ControllerTest extends AbstractControllerTest {
                                         "6.9.22.4.b - OBD module Engine #1 (0) did not provide a response to Global query and did not provide a NACK for the DS query");
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -183,7 +182,6 @@ public class Part09Step22ControllerTest extends AbstractControllerTest {
         verify(diagnosticMessageModule).requestDM2(any(), eq(1));
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -207,7 +205,6 @@ public class Part09Step22ControllerTest extends AbstractControllerTest {
         verify(diagnosticMessageModule).requestDM2(any(), eq(1));
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
 
         verify(mockListener).addOutcome(PART_NUMBER,
@@ -232,7 +229,6 @@ public class Part09Step22ControllerTest extends AbstractControllerTest {
         verify(diagnosticMessageModule).requestDM2(any(), eq(0));
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
 
         verify(mockListener).addOutcome(PART_NUMBER,
@@ -256,7 +252,6 @@ public class Part09Step22ControllerTest extends AbstractControllerTest {
         verify(diagnosticMessageModule).requestDM2(any(), eq(0));
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
 
         verify(mockListener).addOutcome(PART_NUMBER,
@@ -281,7 +276,6 @@ public class Part09Step22ControllerTest extends AbstractControllerTest {
         verify(diagnosticMessageModule).requestDM2(any(), eq(0));
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
 
         verify(mockListener).addOutcome(PART_NUMBER,

--- a/src-test/org/etools/j1939_84/controllers/part09/Part09Step23ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part09/Part09Step23ControllerTest.java
@@ -143,7 +143,6 @@ public class Part09Step23ControllerTest extends AbstractControllerTest {
         verify(diagnosticMessageModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -161,7 +160,6 @@ public class Part09Step23ControllerTest extends AbstractControllerTest {
         verify(diagnosticMessageModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -184,7 +182,6 @@ public class Part09Step23ControllerTest extends AbstractControllerTest {
                                         "6.9.22.2.a - ECU Engine #1 (0) reported MIL status of alternate off");
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
     }
 
@@ -197,7 +194,6 @@ public class Part09Step23ControllerTest extends AbstractControllerTest {
         verify(diagnosticMessageModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
 
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL, "6.9.23.2.c - No OBD ECU provided a DM1");
@@ -218,7 +214,6 @@ public class Part09Step23ControllerTest extends AbstractControllerTest {
         verify(diagnosticMessageModule).readDM1(any());
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals("", listener.getResults());
 
         verify(mockListener).addOutcome(PART_NUMBER,

--- a/src-test/org/etools/j1939_84/controllers/part09/Part09Step25ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part09/Part09Step25ControllerTest.java
@@ -207,8 +207,6 @@ public class Part09Step25ControllerTest extends AbstractControllerTest {
 
         assertEquals(expected, listener.getResults());
 
-        assertEquals("", listener.getMilestones());
-
         verify(engineSpeedModule, atLeastOnce()).getKeyState();
     }
 
@@ -278,8 +276,6 @@ public class Part09Step25ControllerTest extends AbstractControllerTest {
                 "Waiting for Key ON/Engine OFF..." + NL +
                 "User cancelled testing at Part 9 Step 25";
         assertEquals(expectedMessages, listener.getMessages());
-
-        assertEquals("", listener.getMilestones());
 
         String expected = "Initial Engine Speed = 0.0 RPMs" + NL;
         expected += "Final Engine Speed = 0.0 RPMs" + NL;

--- a/src-test/org/etools/j1939_84/controllers/part10/Part10Step02ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part10/Part10Step02ControllerTest.java
@@ -205,14 +205,12 @@ public class Part10Step02ControllerTest extends AbstractControllerTest {
         expectedMessages.append("Waiting for Key ON/Engine RUNNING...");
         assertEquals(expectedMessages.toString(), listener.getMessages());
 
-        assertEquals("", listener.getMilestones());
         String expected = "Initial Engine Speed = 0.0 RPMs" + NL;
         expected += "Final Engine Speed = 0.0 RPMs" + NL;
         expected += "Initial Engine Speed = 0.0 RPMs" + NL;
         expected += "Final Engine Speed = 500.0 RPMs" + NL;
 
         assertEquals(expected, listener.getResults());
-        assertEquals("", listener.getMilestones());
 
         verify(engineSpeedModule, atLeastOnce()).getKeyState();
     }
@@ -289,15 +287,12 @@ public class Part10Step02ControllerTest extends AbstractControllerTest {
         expectedMessages.append("User cancelled testing at Part 10 Step 2");
         assertEquals(expectedMessages.toString(), listener.getMessages());
 
-        assertEquals("", listener.getMilestones());
         String expected = "Initial Engine Speed = 0.0 RPMs" + NL;
         expected += "Final Engine Speed = 0.0 RPMs" + NL;
         expected += "Initial Engine Speed = 0.0 RPMs" + NL;
         expected += "Final Engine Speed = 500.0 RPMs" + NL;
 
         assertEquals(expected, listener.getResults());
-        assertEquals("", listener.getMilestones());
-
         verify(engineSpeedModule, atLeastOnce()).getKeyState();
     }
 }

--- a/src-test/org/etools/j1939_84/controllers/part10/Part10Step05ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part10/Part10Step05ControllerTest.java
@@ -205,14 +205,12 @@ public class Part10Step05ControllerTest extends AbstractControllerTest {
         expectedMessages.append("Waiting for Key ON/Engine RUNNING...");
         assertEquals(expectedMessages.toString(), listener.getMessages());
 
-        assertEquals("", listener.getMilestones());
         String expected = "Initial Engine Speed = 0.0 RPMs" + NL;
         expected += "Final Engine Speed = 0.0 RPMs" + NL;
         expected += "Initial Engine Speed = 0.0 RPMs" + NL;
         expected += "Final Engine Speed = 500.0 RPMs" + NL;
 
         assertEquals(expected, listener.getResults());
-        assertEquals("", listener.getMilestones());
 
         verify(engineSpeedModule, atLeastOnce()).getKeyState();
     }
@@ -289,14 +287,12 @@ public class Part10Step05ControllerTest extends AbstractControllerTest {
         expectedMessages.append("User cancelled testing at Part 10 Step 5");
         assertEquals(expectedMessages.toString(), listener.getMessages());
 
-        assertEquals("", listener.getMilestones());
         String expected = "Initial Engine Speed = 0.0 RPMs" + NL;
         expected += "Final Engine Speed = 0.0 RPMs" + NL;
         expected += "Initial Engine Speed = 0.0 RPMs" + NL;
         expected += "Final Engine Speed = 500.0 RPMs" + NL;
 
         assertEquals(expected, listener.getResults());
-        assertEquals("", listener.getMilestones());
 
         verify(engineSpeedModule, atLeastOnce()).getKeyState();
     }

--- a/src-test/org/etools/j1939_84/modules/DiagnosticMessageModuleTest.java
+++ b/src-test/org/etools/j1939_84/modules/DiagnosticMessageModuleTest.java
@@ -547,7 +547,6 @@ public class DiagnosticMessageModuleTest {
         assertEquals(result, instance.requestDM21(listener, 0x00));
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(j1939).createRequestPacket(pgn, 0x00);
         verify(j1939).read(anyLong(), any());
@@ -579,7 +578,6 @@ public class DiagnosticMessageModuleTest {
         assertEquals(result, instance.requestDM21(listener, 0x00));
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(j1939).createRequestPacket(pgn, 0x00);
         verify(j1939).read(anyLong(), any());
@@ -611,7 +609,6 @@ public class DiagnosticMessageModuleTest {
         assertEquals(result, instance.requestDM21(listener));
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(j1939).createRequestPacket(pgn, GLOBAL_ADDR);
         verify(j1939).read(anyLong(), any());
@@ -645,7 +642,6 @@ public class DiagnosticMessageModuleTest {
         assertEquals(result, instance.requestDM21(listener));
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(j1939).createRequestPacket(pgn, GLOBAL_ADDR);
         verify(j1939).read(anyLong(), any());
@@ -881,7 +877,6 @@ public class DiagnosticMessageModuleTest {
         assertEquals(RequestResult.empty(false), instance.requestDM23(listener));
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(j1939).createRequestPacket(pgn, GLOBAL_ADDR);
         verify(j1939).read(anyLong(), any());
@@ -918,7 +913,6 @@ public class DiagnosticMessageModuleTest {
         assertEquals(expectedResult, instance.requestDM25(listener, 0x00));
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(j1939).createRequestPacket(pgn, 0x00);
         verify(j1939).read(anyLong(), any());
@@ -940,7 +934,6 @@ public class DiagnosticMessageModuleTest {
         assertEquals(expectedResult, instance.requestDM25(listener, 0x00));
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(j1939).createRequestPacket(pgn, 0x00);
         verify(j1939).read(anyLong(), any());
@@ -987,7 +980,6 @@ public class DiagnosticMessageModuleTest {
         assertEquals(expectedResult, instance.requestDM25(listener, 0x00));
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(j1939).createRequestPacket(pgn, 0x00);
         verify(j1939).read(anyLong(), any());
@@ -1070,7 +1062,6 @@ public class DiagnosticMessageModuleTest {
         assertEquals(expectedResult, instance.requestDM26(listener, 0x00));
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(j1939).createRequestPacket(pgn, 0x00);
         verify(j1939).read(anyLong(), any());
@@ -1097,7 +1088,6 @@ public class DiagnosticMessageModuleTest {
         assertEquals(expectedResult, instance.requestDM26(listener, 0x17));
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(j1939).createRequestPacket(pgn, 0x17);
         verify(j1939).read(anyLong(), any());
@@ -1167,7 +1157,6 @@ public class DiagnosticMessageModuleTest {
         assertEquals(expectedResult, instance.requestDM26(listener));
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(j1939).createRequestPacket(pgn, GLOBAL_ADDR);
         verify(j1939).read(anyLong(), any());
@@ -1207,7 +1196,6 @@ public class DiagnosticMessageModuleTest {
         assertEquals(expectedResult, instance.requestDM26(listener));
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(j1939).createRequestPacket(pgn, GLOBAL_ADDR);
         verify(j1939).read(anyLong(), any());
@@ -1229,7 +1217,6 @@ public class DiagnosticMessageModuleTest {
         assertEquals(RequestResult.empty(false), instance.requestDM26(listener));
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(j1939).createRequestPacket(pgn, 0xFF);
         verify(j1939).read(anyLong(), any());
@@ -1267,7 +1254,6 @@ public class DiagnosticMessageModuleTest {
         assertEquals(expectedResult, instance.requestDM27(listener, 0x00));
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(j1939).createRequestPacket(pgn, 0x00);
         verify(j1939).read(anyLong(), any());
@@ -1314,7 +1300,6 @@ public class DiagnosticMessageModuleTest {
         assertEquals(expectedResult, instance.requestDM27(listener, 0x00));
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(j1939).createRequestPacket(pgn, 0x00);
         verify(j1939).read(anyLong(), any());
@@ -1339,7 +1324,6 @@ public class DiagnosticMessageModuleTest {
         assertEquals(expectedResult, instance.requestDM27(listener, 0x17));
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(j1939).createRequestPacket(pgn, 0x17);
         verify(j1939).read(anyLong(), any());
@@ -1526,7 +1510,6 @@ public class DiagnosticMessageModuleTest {
         assertEquals(expectedResult, instance.requestDM28(listener));
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(j1939).createRequestPacket(pgn, GLOBAL_ADDR);
         verify(j1939).read(anyLong(), any());
@@ -1549,7 +1532,6 @@ public class DiagnosticMessageModuleTest {
         assertEquals(BusResult.empty(), instance.requestDM29(listener, 0x00));
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(j1939).createRequestPacket(pgn, 0x00);
         verify(j1939).read(anyLong(), any());
@@ -1589,7 +1571,6 @@ public class DiagnosticMessageModuleTest {
         assertEquals(expectedResult, instance.requestDM29(listener, 0x00));
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(j1939).createRequestPacket(pgn, 0x00);
         verify(j1939).read(anyLong(), any());
@@ -1609,7 +1590,6 @@ public class DiagnosticMessageModuleTest {
         assertEquals(RequestResult.empty(false), instance.requestDM29(listener));
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(j1939).createRequestPacket(pgn, GLOBAL_ADDR);
         verify(j1939).read(anyLong(), any());
@@ -1649,7 +1629,6 @@ public class DiagnosticMessageModuleTest {
         assertEquals(expectedResult, instance.requestDM29(listener));
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(j1939).createRequestPacket(pgn, GLOBAL_ADDR);
         verify(j1939).read(anyLong(), any());
@@ -1673,7 +1652,6 @@ public class DiagnosticMessageModuleTest {
         assertTrue(instance.requestDM2(listener, 0x17).getPacket().isEmpty());
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(j1939).createRequestPacket(pgn, 0x17);
         verify(j1939).read(anyLong(), any());
@@ -1713,7 +1691,6 @@ public class DiagnosticMessageModuleTest {
         assertEquals(packet1, busResult.getPacket().get().left.get());
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(j1939).createRequestPacket(pgn, 0x01);
         verify(j1939).read(anyLong(), any());
@@ -1782,7 +1759,6 @@ public class DiagnosticMessageModuleTest {
         assertEquals(expectedPackets, instance.requestDM2(listener).getPackets());
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
         assertEquals(expected, listener.getResults());
 
         verify(j1939).createRequestPacket(pgn, GLOBAL_ADDR);
@@ -1832,7 +1808,6 @@ public class DiagnosticMessageModuleTest {
         assertEquals(expectedResult, instance.requestDM2(listener));
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(j1939).createRequestPacket(pgn, 0xFF);
         verify(j1939).read(anyLong(), any());
@@ -1855,7 +1830,6 @@ public class DiagnosticMessageModuleTest {
         assertEquals(new ArrayList<DM2PreviouslyActiveDTC>(), instance.requestDM2(listener).getPackets());
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(j1939).createRequestPacket(pgn, GLOBAL_ADDR);
         verify(j1939).read(anyLong(), any());
@@ -1880,7 +1854,6 @@ public class DiagnosticMessageModuleTest {
         assertEquals(expectedResult, instance.requestDM31(listener, 0x00));
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(j1939).createRequestPacket(pgn, 0x00);
         verify(j1939).read(anyLong(), any());
@@ -1941,7 +1914,6 @@ public class DiagnosticMessageModuleTest {
         assertEquals(expectedResult, instance.requestDM31(listener, 0x21));
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(j1939).createRequestPacket(pgn, 0x21);
         verify(j1939).read(anyLong(), any());
@@ -1961,7 +1933,6 @@ public class DiagnosticMessageModuleTest {
         assertEquals(RequestResult.empty(false), instance.requestDM31(listener));
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(j1939).createRequestPacket(pgn, GLOBAL_ADDR);
         verify(j1939).read(anyLong(), any());
@@ -2017,7 +1988,6 @@ public class DiagnosticMessageModuleTest {
         assertEquals(expectedResult, instance.requestDM31(listener));
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(j1939).createRequestPacket(pgn, GLOBAL_ADDR);
         verify(j1939).read(anyLong(), any());
@@ -2058,7 +2028,6 @@ public class DiagnosticMessageModuleTest {
 
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(j1939).createRequestPacket(pgn, GLOBAL_ADDR);
         verify(j1939).read(anyLong(), any());
@@ -2083,7 +2052,6 @@ public class DiagnosticMessageModuleTest {
         assertEquals(expectedResult, instance.requestDM33(listener, 0x00));
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(j1939).createRequestPacket(pgn, 0x00);
         verify(j1939).read(anyLong(), any());
@@ -2122,7 +2090,6 @@ public class DiagnosticMessageModuleTest {
         assertEquals(expectedResult, instance.requestDM33(listener));
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(j1939).createRequestPacket(pgn, GLOBAL_ADDR);
         verify(j1939).read(anyLong(), any());
@@ -2143,7 +2110,6 @@ public class DiagnosticMessageModuleTest {
         assertEquals(RequestResult.empty(false), instance.requestDM33(listener));
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(j1939).createRequestPacket(pgn, GLOBAL_ADDR);
         verify(j1939).read(anyLong(), any());
@@ -2181,7 +2147,6 @@ public class DiagnosticMessageModuleTest {
         assertEquals(result, instance.requestDM6(listener, 0x00));
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(j1939).createRequestPacket(pgn, 0x00);
         verify(j1939).read(anyLong(), any());
@@ -2229,7 +2194,6 @@ public class DiagnosticMessageModuleTest {
         assertEquals(result, instance.requestDM6(listener, 0x00));
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(j1939).createRequestPacket(pgn, 0x00);
         verify(j1939).read(anyLong(), any());
@@ -2255,7 +2219,6 @@ public class DiagnosticMessageModuleTest {
         assertEquals(result, instance.requestDM6(listener, 0x21));
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(j1939).createRequestPacket(pgn, 0x21);
         verify(j1939).read(anyLong(), any());
@@ -2314,7 +2277,6 @@ public class DiagnosticMessageModuleTest {
         assertEquals(result, instance.requestDM6(listener));
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(j1939).createRequestPacket(pgn, GLOBAL_ADDR);
         verify(j1939).read(anyLong(), any());
@@ -2359,7 +2321,6 @@ public class DiagnosticMessageModuleTest {
         assertEquals(result, instance.requestDM6(listener));
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(j1939).createRequestPacket(pgn, GLOBAL_ADDR);
         verify(j1939).read(anyLong(), any());
@@ -2379,7 +2340,6 @@ public class DiagnosticMessageModuleTest {
         assertEquals(RequestResult.empty(false), instance.requestDM6(listener));
         assertEquals(expected, listener.getResults());
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getMilestones());
 
         verify(j1939).createRequestPacket(pgn, GLOBAL_ADDR);
         verify(j1939).read(anyLong(), any());

--- a/src-test/org/etools/j1939_84/ui/UserInterfacePresenterTest.java
+++ b/src-test/org/etools/j1939_84/ui/UserInterfacePresenterTest.java
@@ -32,6 +32,7 @@ import org.etools.j1939_84.bus.BusException;
 import org.etools.j1939_84.bus.RP1210;
 import org.etools.j1939_84.bus.RP1210Bus;
 import org.etools.j1939_84.bus.j1939.J1939;
+import org.etools.j1939_84.controllers.Controller;
 import org.etools.j1939_84.controllers.OverallController;
 import org.etools.j1939_84.controllers.ResultsListener;
 import org.etools.j1939_84.modules.ReportFileModule;
@@ -622,7 +623,7 @@ public class UserInterfacePresenterTest {
 
     @Test
     public void testOnStopButtonClicked() {
-        when(overallController.isActive()).thenReturn(true);
+        when(Controller.isActive()).thenReturn(true);
 
         instance.onStopButtonClicked();
 
@@ -641,7 +642,7 @@ public class UserInterfacePresenterTest {
 
     @Test
     public void testOnStopButtonClickedWithStoppedController() {
-        when(overallController.isActive()).thenReturn(false);
+        when(Controller.isActive()).thenReturn(false);
 
         instance.onStopButtonClicked();
 

--- a/src/org/etools/j1939_84/bus/simulated/Engine.java
+++ b/src/org/etools/j1939_84/bus/simulated/Engine.java
@@ -61,7 +61,7 @@ public class Engine implements AutoCloseable {
 
     private static final byte[] ENGINE_HOURS = as4Bytes(3564 * 20); // hrs
     private static final byte[] ENGINE_MODEL_YEAR = "2015E-MYUS HD OBD   ".getBytes(A_UTF8);
-    private static final byte[] ENGINE_SPEED = as2Bytes(400 * 8); // rpm
+    private static final byte[] ENGINE_SPEED = as2Bytes(1400 * 8); // rpm
     private static final byte[] ENGINE_SPEED_ZERO = as2Bytes(0); // rpm
     private static final byte NA = (byte) 0xFF;
     private static final byte[] NA3 = new byte[] { NA, NA, NA };

--- a/src/org/etools/j1939_84/controllers/Controller.java
+++ b/src/org/etools/j1939_84/controllers/Controller.java
@@ -14,7 +14,6 @@ import org.etools.j1939_84.bus.j1939.J1939;
 import org.etools.j1939_84.controllers.ResultsListener.MessageType;
 import org.etools.j1939_84.model.Outcome;
 import org.etools.j1939_84.model.PartResult;
-import org.etools.j1939_84.model.StepResult;
 import org.etools.j1939_84.model.VehicleInformation;
 import org.etools.j1939_84.model.VehicleInformationListener;
 import org.etools.j1939_84.modules.BannerModule;
@@ -243,7 +242,7 @@ public abstract class Controller {
      *
      * @return {@link Logger}
      */
-    protected Logger getLogger() {
+    protected static Logger getLogger() {
         return J1939_84.getLogger();
     }
 
@@ -312,7 +311,7 @@ public abstract class Controller {
      *
      * @return boolean
      */
-    public boolean isActive() {
+    public static boolean isActive() {
         return ending == null;
     }
 
@@ -404,26 +403,6 @@ public abstract class Controller {
         @Override
         public void addOutcome(int partNumber, int stepNumber, Outcome outcome, String message) {
             Arrays.stream(listeners).forEach(l -> l.addOutcome(partNumber, stepNumber, outcome, message));
-        }
-
-        @Override
-        public void beginPart(PartResult partResult) {
-            Arrays.stream(listeners).forEach(l -> l.beginPart(partResult));
-        }
-
-        @Override
-        public void beginStep(StepResult stepResult) {
-            Arrays.stream(listeners).forEach(l -> l.beginStep(stepResult));
-        }
-
-        @Override
-        public void endPart(PartResult partResult) {
-            Arrays.stream(listeners).forEach(l -> l.endPart(partResult));
-        }
-
-        @Override
-        public void endStep(StepResult stepResult) {
-            Arrays.stream(listeners).forEach(l -> l.endStep(stepResult));
         }
 
         @Override

--- a/src/org/etools/j1939_84/controllers/PartController.java
+++ b/src/org/etools/j1939_84/controllers/PartController.java
@@ -9,6 +9,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Executor;
 
+import org.etools.j1939_84.model.ActionOutcome;
+import org.etools.j1939_84.model.Outcome;
 import org.etools.j1939_84.model.PartResult;
 import org.etools.j1939_84.model.StepResult;
 import org.etools.j1939_84.modules.BannerModule;
@@ -73,10 +75,18 @@ public abstract class PartController extends Controller {
             getListener().onResult("");
             getListener().onResult("End " + stepResult);
             getListener().onResult("");
+
+            recordStepResult(stepResult);
         }
         getListener().onResult("");
         getListener().onResult("End " + partResult);
         getListener().onResult("");
+    }
+
+    private static void recordStepResult(StepResult stepResult) {
+        if (stepResult.getOutcome() == Outcome.INCOMPLETE) {
+            stepResult.addResult(new ActionOutcome(Outcome.PASS, null));
+        }
     }
 
     protected PartResult getPartResult() {

--- a/src/org/etools/j1939_84/controllers/PartController.java
+++ b/src/org/etools/j1939_84/controllers/PartController.java
@@ -58,21 +58,18 @@ public abstract class PartController extends Controller {
 
         PartResult partResult = getPartResult();
         getListener().onResult("");
-        getListener().beginPart(partResult);
         getListener().onResult("Start " + partResult);
         getListener().onResult("");
 
         for (StepController controller : getStepControllers()) {
             StepResult stepResult = getPartResult().getStepResult(controller.getStepNumber());
 
-            getListener().beginStep(stepResult);
             getListener().onResult("Start " + stepResult);
             getListener().onResult("");
 
             incrementProgress(stepResult.toString());
             controller.run(getListener(), getJ1939());
 
-            getListener().endStep(stepResult);
             getListener().onResult("");
             getListener().onResult("End " + stepResult);
             getListener().onResult("");
@@ -80,7 +77,6 @@ public abstract class PartController extends Controller {
         getListener().onResult("");
         getListener().onResult("End " + partResult);
         getListener().onResult("");
-        getListener().endPart(partResult);
     }
 
     protected PartResult getPartResult() {

--- a/src/org/etools/j1939_84/controllers/ReplayListener.java
+++ b/src/org/etools/j1939_84/controllers/ReplayListener.java
@@ -8,8 +8,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.etools.j1939_84.model.Outcome;
-import org.etools.j1939_84.model.PartResult;
-import org.etools.j1939_84.model.StepResult;
 import org.etools.j1939_84.model.VehicleInformation;
 import org.etools.j1939_84.model.VehicleInformationListener;
 
@@ -19,26 +17,6 @@ public class ReplayListener implements ResultsListener {
 
     @Override
     public void addOutcome(int partNumber, int stepNumber, Outcome outcome, String message) {
-
-    }
-
-    @Override
-    public void beginPart(PartResult partResult) {
-
-    }
-
-    @Override
-    public void beginStep(StepResult stepResult) {
-
-    }
-
-    @Override
-    public void endPart(PartResult partResult) {
-
-    }
-
-    @Override
-    public void endStep(StepResult stepResult) {
 
     }
 

--- a/src/org/etools/j1939_84/controllers/ResultsListener.java
+++ b/src/org/etools/j1939_84/controllers/ResultsListener.java
@@ -8,8 +8,6 @@ import java.util.List;
 import javax.swing.JOptionPane;
 
 import org.etools.j1939_84.model.Outcome;
-import org.etools.j1939_84.model.PartResult;
-import org.etools.j1939_84.model.StepResult;
 import org.etools.j1939_84.model.VehicleInformation;
 import org.etools.j1939_84.model.VehicleInformationListener;
 
@@ -24,22 +22,6 @@ public interface ResultsListener {
 
         @Override
         public void addOutcome(int partNumber, int stepNumber, Outcome outcome, String message) {
-        }
-
-        @Override
-        public void beginPart(PartResult partResult) {
-        }
-
-        @Override
-        public void beginStep(StepResult stepResult) {
-        }
-
-        @Override
-        public void endPart(PartResult partResult) {
-        }
-
-        @Override
-        public void endStep(StepResult stepResult) {
         }
 
         @Override
@@ -85,13 +67,8 @@ public interface ResultsListener {
 
     void addOutcome(int partNumber, int stepNumber, Outcome outcome, String message);
 
-    void beginPart(PartResult partResult);
 
-    void beginStep(StepResult stepResult);
 
-    void endPart(PartResult partResult);
-
-    void endStep(StepResult stepResult);
 
     /**
      * Called when the {@link Controller} has completed
@@ -195,7 +172,7 @@ public interface ResultsListener {
     /**
      * The different types of messages which can be displayed to the user
      */
-    public enum MessageType {
+    enum MessageType {
         // The values correspond to JOptionPane Types
 
         ERROR(JOptionPane.OK_CANCEL_OPTION),

--- a/src/org/etools/j1939_84/controllers/StepController.java
+++ b/src/org/etools/j1939_84/controllers/StepController.java
@@ -134,11 +134,13 @@ public abstract class StepController extends Controller {
 
     protected void ensureKeyStateIs(KeyState requestedKeyState) throws InterruptedException {
         getListener().onResult("Initial Engine Speed = " + getEngineSpeedAsString());
-        if (getCurrentKeyState() != requestedKeyState && !isDevEnv()) {
-            getListener().onUrgentMessage("Please turn " + requestedKeyState,
-                                          "Adjust Key Switch",
-                                          WARNING,
-                                          getQuestionListener());
+        if (getCurrentKeyState() != requestedKeyState) {
+            if (!isDevEnv()) {
+                getListener().onUrgentMessage("Please turn " + requestedKeyState,
+                                              "Adjust Key Switch",
+                                              WARNING,
+                                              getQuestionListener());
+            }
             while (getCurrentKeyState() != requestedKeyState) {
                 updateProgress("Waiting for " + requestedKeyState + "...");
                 getDateTimeModule().pauseFor(500);

--- a/src/org/etools/j1939_84/controllers/part01/Part01Step03Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step03Controller.java
@@ -21,7 +21,6 @@ import org.etools.j1939_84.modules.DateTimeModule;
 import org.etools.j1939_84.modules.DiagnosticMessageModule;
 import org.etools.j1939_84.modules.EngineSpeedModule;
 import org.etools.j1939_84.modules.VehicleInformationModule;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * 6.1.3 DM5: Diagnostic Readiness 1
@@ -112,7 +111,6 @@ public class Part01Step03Controller extends StepController {
         }
     }
 
-    @NotNull
     private Integer getAddressClaimFunction(DM5DiagnosticReadinessPacket p) {
         return getDataRepository().getVehicleInformation()
                                   .getAddressClaim()

--- a/src/org/etools/j1939_84/controllers/part11/Part11Step07Controller.java
+++ b/src/org/etools/j1939_84/controllers/part11/Part11Step07Controller.java
@@ -155,6 +155,7 @@ public class Part11Step07Controller extends StepController {
             secondsToGo = calculateSecondsRemaining();
         } while (secondsToGo > 0);
 
+        executor.shutdownNow();
         isComplete.set(true);
     }
 

--- a/src/org/etools/j1939_84/modules/ReportFileModule.java
+++ b/src/org/etools/j1939_84/modules/ReportFileModule.java
@@ -25,8 +25,6 @@ import org.etools.j1939_84.controllers.QuestionListener;
 import org.etools.j1939_84.controllers.ResultsListener;
 import org.etools.j1939_84.model.ActionOutcome;
 import org.etools.j1939_84.model.Outcome;
-import org.etools.j1939_84.model.PartResult;
-import org.etools.j1939_84.model.StepResult;
 import org.etools.j1939_84.model.VehicleInformation;
 import org.etools.j1939_84.model.VehicleInformationListener;
 
@@ -79,28 +77,6 @@ public class ReportFileModule extends FunctionalModule implements ResultsListene
     public void addOutcome(int partNumber, int stepNumber, Outcome outcome, String message) {
         summaryModule.addOutcome(partNumber, stepNumber, outcome, message);
         onResult(new ActionOutcome(outcome, message).toString());
-    }
-
-    @Override
-    public void beginPart(PartResult partResult) {
-        summaryModule.beginPart(partResult);
-    }
-
-    @Override
-    public void beginStep(StepResult stepResult) {
-
-    }
-
-    @Override
-    public void endPart(PartResult partResult) {
-        // onResult(NL);
-        // onResult("End Part " + partResult);
-    }
-
-    @Override
-    public void endStep(StepResult stepResult) {
-        // onResult(NL);
-        summaryModule.endStep(stepResult);
     }
 
     @Override

--- a/src/org/etools/j1939_84/modules/SummaryModule.java
+++ b/src/org/etools/j1939_84/modules/SummaryModule.java
@@ -38,16 +38,6 @@ public class SummaryModule {
         stepResult.addResult(new ActionOutcome(outcome, message));
     }
 
-    public void beginPart(PartResult partResult) {
-        getPartResults().add(partResult);
-    }
-
-    public void endStep(StepResult stepResult) {
-        if (stepResult.getOutcome() == Outcome.INCOMPLETE) {
-            stepResult.addResult(new ActionOutcome(Outcome.PASS, null));
-        }
-    }
-
     public String generateSummary() {
         StringBuilder sb = new StringBuilder();
         for (PartResult partResult : getPartResults()) {
@@ -77,7 +67,7 @@ public class SummaryModule {
                                .count();
     }
 
-    private String println(IResult iResult) {
+    private static String println(IResult iResult) {
         String name = iResult.toString();
 
         Outcome outcome = iResult.getOutcome();

--- a/src/org/etools/j1939_84/ui/UserInterfacePresenter.java
+++ b/src/org/etools/j1939_84/ui/UserInterfacePresenter.java
@@ -349,7 +349,7 @@ public class UserInterfacePresenter implements UserInterfaceContract.Presenter {
      */
     @Override
     public void onStopButtonClicked() {
-        if (Controller.isActive()) {
+        if (overallController.isActive()) {
             overallController.stop();
         }
         getResultsListener().onComplete(false);
@@ -357,7 +357,7 @@ public class UserInterfacePresenter implements UserInterfaceContract.Presenter {
         getView().setStopButtonEnabled(false);
     }
 
-    private static Logger getLogger() {
+    private Logger getLogger() {
         return J1939_84.getLogger();
     }
 

--- a/src/org/etools/j1939_84/ui/UserInterfacePresenter.java
+++ b/src/org/etools/j1939_84/ui/UserInterfacePresenter.java
@@ -24,13 +24,12 @@ import org.etools.j1939_84.bus.RP1210;
 import org.etools.j1939_84.bus.RP1210Bus;
 import org.etools.j1939_84.bus.j1939.J1939;
 import org.etools.j1939_84.bus.j1939.J1939TP;
+import org.etools.j1939_84.controllers.Controller;
 import org.etools.j1939_84.controllers.OverallController;
 import org.etools.j1939_84.controllers.QuestionListener;
 import org.etools.j1939_84.controllers.ResultsListener;
 import org.etools.j1939_84.model.ActionOutcome;
 import org.etools.j1939_84.model.Outcome;
-import org.etools.j1939_84.model.PartResult;
-import org.etools.j1939_84.model.StepResult;
 import org.etools.j1939_84.model.VehicleInformation;
 import org.etools.j1939_84.model.VehicleInformationListener;
 import org.etools.j1939_84.modules.ReportFileModule;
@@ -350,7 +349,7 @@ public class UserInterfacePresenter implements UserInterfaceContract.Presenter {
      */
     @Override
     public void onStopButtonClicked() {
-        if (overallController.isActive()) {
+        if (Controller.isActive()) {
             overallController.stop();
         }
         getResultsListener().onComplete(false);
@@ -358,7 +357,7 @@ public class UserInterfacePresenter implements UserInterfaceContract.Presenter {
         getView().setStopButtonEnabled(false);
     }
 
-    private Logger getLogger() {
+    private static Logger getLogger() {
         return J1939_84.getLogger();
     }
 
@@ -390,22 +389,6 @@ public class UserInterfacePresenter implements UserInterfaceContract.Presenter {
             @Override
             public void addOutcome(int partNumber, int stepNumber, Outcome outcome, String message) {
                 onResult(new ActionOutcome(outcome, message).toString());
-            }
-
-            @Override
-            public void beginPart(PartResult partResult) {
-            }
-
-            @Override
-            public void beginStep(StepResult stepResult) {
-            }
-
-            @Override
-            public void endPart(PartResult partResult) {
-            }
-
-            @Override
-            public void endStep(StepResult stepResult) {
             }
 
             @Override
@@ -532,7 +515,7 @@ public class UserInterfacePresenter implements UserInterfaceContract.Presenter {
      *                         if the file cannot be used
      */
 
-    private File setupReportFile(File file) throws IOException {
+    private static File setupReportFile(File file) throws IOException {
         File reportFile = file;
         if (!file.exists()) {
             // Append the file extension if the file doesn't have one.


### PR DESCRIPTION
Fix #737 - remove the unused Milestone tracking for overall test progress.  We went in a different direction.