### PR TITLE
Fix #833 - Test 9.6 makes multiple requests for the same SPN

### DIFF
--- a/src-test/org/etools/j1939_84/controllers/part09/Part09Step06ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part09/Part09Step06ControllerTest.java
@@ -130,8 +130,9 @@ public class Part09Step06ControllerTest extends AbstractControllerTest {
     public void testHappyPathNoFailures() {
         OBDModuleInformation obdModuleInformation = new OBDModuleInformation(0);
         ScaledTestResult str1 = ScaledTestResult.create(247, 123, 14, 0, 5, 10, 1);
-        ScaledTestResult str2 = ScaledTestResult.create(247, 456, 3, 0, 5, 10, 1);
-        obdModuleInformation.setNonInitializedTests(List.of(str1, str2));
+        ScaledTestResult str2 = ScaledTestResult.create(247, 123, 15, 0, 5, 10, 1);
+        ScaledTestResult str3 = ScaledTestResult.create(247, 456, 3, 0, 5, 10, 1);
+        obdModuleInformation.setNonInitializedTests(List.of(str1, str2, str3));
         dataRepository.putObdModule(obdModuleInformation);
 
         dataRepository.putObdModule(new OBDModuleInformation(1));

--- a/src/org/etools/j1939_84/controllers/part09/Part09Step06Controller.java
+++ b/src/org/etools/j1939_84/controllers/part09/Part09Step06Controller.java
@@ -64,7 +64,10 @@ public class Part09Step06Controller extends StepController {
         for (OBDModuleInformation moduleInformation : getDataRepository().getObdModules()) {
             moduleInformation.getNonInitializedTests()
                              .stream()
-                             .map(str -> requestTestResults(moduleInformation, str))
+                             .map(ScaledTestResult::getSpn)
+                             .distinct()
+                             .sorted()
+                             .map(spn -> requestTestResults(moduleInformation, spn))
                              .flatMap(Collection::stream)
                              .map(DM30ScaledTestResultsPacket::getTestResults)
                              .flatMap(Collection::stream)
@@ -79,11 +82,11 @@ public class Part09Step06Controller extends StepController {
     }
 
     private List<DM30ScaledTestResultsPacket> requestTestResults(OBDModuleInformation moduleInformation,
-                                                                 ScaledTestResult str) {
+                                                                 int spn) {
         return getDiagnosticMessageModule().requestTestResults(getListener(),
                                                                moduleInformation.getSourceAddress(),
                                                                247,
-                                                               str.getSpn(),
+                                                               spn,
                                                                31);
     }
 


### PR DESCRIPTION
The test results need filtered to a distinct list of SPNs.  I sorted them so they are in a consistent order.