### PR TITLE
Fix #826 - Part 11 Step 7 display the actual time left to run at 1150 RPM in the dialog

### DIFF
--- a/src-test/org/etools/j1939_84/controllers/part11/Part11Step07ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part11/Part11Step07ControllerTest.java
@@ -225,10 +225,9 @@ public class Part11Step07ControllerTest extends AbstractControllerTest {
         for (int i = 180; i > 0; i--) {
             expectedMessages.append("Step 6.11.7.1.b - Waiting ").append(i).append(" seconds").append(NL);
         }
-        expectedMessages.append("Step 6.11.7.1.c - Increase engine speed over 1150 rpm for 300 seconds").append(NL);
         expectedMessages.append("Step 6.11.7.1.c - Increase engine speed over 1150 rpm for 2 seconds").append(NL);
         expectedMessages.append("Step 6.11.7.1.c - Increase engine speed over 1150 rpm for 1 seconds").append(NL);
-        for (int i = 437; i > 0; i--) {
+        for (int i = 438; i > 0; i--) {
             expectedMessages.append("Step 6.11.7.4.a - Continue to run engine at idle for an additional ")
                             .append(i)
                             .append(" seconds");
@@ -269,7 +268,7 @@ public class Part11Step07ControllerTest extends AbstractControllerTest {
             return null;
         }).when(mockListener).onUrgentMessage(any(), any(), eq(WARNING), any());
 
-        when(engineSpeedModule.secondsAtSpeed()).thenReturn(299L).thenReturn(300L);
+        when(engineSpeedModule.secondsAtSpeed()).thenReturn(298L).thenReturn(299L).thenReturn(300L);
 
         runTest();
 
@@ -309,7 +308,7 @@ public class Part11Step07ControllerTest extends AbstractControllerTest {
             return null;
         }).when(mockListener).onUrgentMessage(any(), any(), eq(WARNING), any());
 
-        when(engineSpeedModule.secondsAtSpeed()).thenReturn(299L).thenReturn(300L);
+        when(engineSpeedModule.secondsAtSpeed()).thenReturn(298L).thenReturn(299L).thenReturn(300L);
 
         runTest();
 

--- a/src/org/etools/j1939_84/controllers/part11/Part11Step07Controller.java
+++ b/src/org/etools/j1939_84/controllers/part11/Part11Step07Controller.java
@@ -120,8 +120,7 @@ public class Part11Step07Controller extends StepController {
         pause("Step 6.11.7.1.b - Waiting %1$d seconds", 3 * 60);
 
         // 6.11.7.1.c. Increase engine speed over 1150 rpm (a minimum of 300 seconds at this speed is required).
-        final long TOTAL_TIME_AT_SPEED = 300;
-        long secondsToGo = TOTAL_TIME_AT_SPEED - getEngineSpeedModule().secondsAtSpeed();
+        long secondsToGo = calculateSecondsRemainingAtSpeed();
 
         String msg = "Please increase engine speed over 1150 rpm for a minimum of %1$d seconds" + NL + NL;
         msg += "Press OK to continue";
@@ -135,7 +134,7 @@ public class Part11Step07Controller extends StepController {
             requestPeriodicMessages();
 
             getDateTimeModule().pauseFor(1000);
-            secondsToGo = TOTAL_TIME_AT_SPEED - getEngineSpeedModule().secondsAtSpeed();
+            secondsToGo = calculateSecondsRemainingAtSpeed();
         } while (secondsToGo > 0);
 
         // 6.11.7.1.f. After 300 seconds have been exceeded, reduce the engine speed back to idle.
@@ -194,6 +193,10 @@ public class Part11Step07Controller extends StepController {
                            .filter(this::isNotReported)
                            .peek(m -> replayListener.replayResults(getListener()))
                            .forEach(this::addFailure);
+    }
+
+    private long calculateSecondsRemainingAtSpeed() {
+        return 300 - getEngineSpeedModule().secondsAtSpeed();
     }
 
     private long calculateSecondsRemaining() {

--- a/src/org/etools/j1939_84/controllers/part11/Part11Step07Controller.java
+++ b/src/org/etools/j1939_84/controllers/part11/Part11Step07Controller.java
@@ -121,12 +121,12 @@ public class Part11Step07Controller extends StepController {
 
         // 6.11.7.1.c. Increase engine speed over 1150 rpm (a minimum of 300 seconds at this speed is required).
         final long TOTAL_TIME_AT_SPEED = 300;
+        long secondsToGo = TOTAL_TIME_AT_SPEED - getEngineSpeedModule().secondsAtSpeed();
 
         String msg = "Please increase engine speed over 1150 rpm for a minimum of %1$d seconds" + NL + NL;
         msg += "Press OK to continue";
-        displayInstructionAndWait(format(msg, TOTAL_TIME_AT_SPEED), "Step 6.11.7.1.c", WARNING);
+        displayInstructionAndWait(format(msg, secondsToGo), "Step 6.11.7.1.c", WARNING);
 
-        long secondsToGo = TOTAL_TIME_AT_SPEED;
         String message = "Step 6.11.7.1.c - Increase engine speed over 1150 rpm for %1$d seconds";
         do {
             updateProgress(format(message, secondsToGo));


### PR DESCRIPTION
Resolves #826 calculate the time left to run at speed before displaying the dialog