### PR TITLE
Fix #844 - N/A for code counts should not indicate data was erased in DM5

### DIFF
--- a/src-test/org/etools/j1939_84/controllers/SectionA5MessageVerifierTest.java
+++ b/src-test/org/etools/j1939_84/controllers/SectionA5MessageVerifierTest.java
@@ -529,12 +529,26 @@ public class SectionA5MessageVerifierTest {
     }
 
     @Test
-    public void checkDM5AsNotErasedSuccess() {
+    public void checkDM5AsNotErasedSuccessWithZeros() {
         var moduleInfo = new OBDModuleInformation(0);
         moduleInfo.set(DM5DiagnosticReadinessPacket.create(0, 1, 1, 0x22), 1);
         dataRepository.putObdModule(moduleInfo);
 
         var packet = DM5DiagnosticReadinessPacket.create(0, 1, 1, 0x22);
+        when(diagnosticMessageModule.requestDM5(listener, 0)).thenReturn(BusResult.of(packet));
+
+        assertTrue(instance.checkDM5(listener, SECTION, 0, false));
+
+        verify(diagnosticMessageModule).requestDM5(listener, 0);
+    }
+
+    @Test
+    public void checkDM5AsNotErasedSuccessWithNotAvailable() {
+        var moduleInfo = new OBDModuleInformation(0);
+        moduleInfo.set(DM5DiagnosticReadinessPacket.create(0, 0xFF, 0xFF, 0x22), 1);
+        dataRepository.putObdModule(moduleInfo);
+
+        var packet = DM5DiagnosticReadinessPacket.create(0, 0xFF, 0xFF, 0x22);
         when(diagnosticMessageModule.requestDM5(listener, 0)).thenReturn(BusResult.of(packet));
 
         assertTrue(instance.checkDM5(listener, SECTION, 0, false));

--- a/src/org/etools/j1939_84/controllers/SectionA5MessageVerifier.java
+++ b/src/org/etools/j1939_84/controllers/SectionA5MessageVerifier.java
@@ -84,8 +84,10 @@ public class SectionA5MessageVerifier {
                                                                 .filter(MonitoredSystemStatus::isEnabled)
                                                                 .noneMatch(MonitoredSystemStatus::isComplete);
 
-                                boolean isNoCodes = p.getActiveCodeCount() == 0
-                                        && p.getPreviouslyActiveCodeCount() == 0;
+                                boolean isNoCodes = (p.getActiveCodeCount() == 0
+                                        || p.getActiveCodeCount() == (byte) 0xFF)
+                                        && (p.getPreviouslyActiveCodeCount() == 0
+                                                || p.getPreviouslyActiveCodeCount() == (byte) 0xFF);
                                 boolean isErased = isNoCodes && isAllTestsIncomplete;
 
                                 var prev = getLatest(DM5DiagnosticReadinessPacket.class, p.getSourceAddress());
@@ -96,8 +98,10 @@ public class SectionA5MessageVerifier {
                                                                     .filter(MonitoredSystemStatus::isEnabled)
                                                                     .noneMatch(MonitoredSystemStatus::isComplete);
 
-                                boolean wasNoCodes = prev.getActiveCodeCount() == 0
-                                        && prev.getPreviouslyActiveCodeCount() == 0;
+                                boolean wasNoCodes = (prev.getActiveCodeCount() == 0
+                                        || prev.getActiveCodeCount() == (byte) 0xFF)
+                                        && (prev.getPreviouslyActiveCodeCount() == 0
+                                                || prev.getPreviouslyActiveCodeCount() == (byte) 0xFF);
                                 boolean wasErased = wasNoCodes && wasAllTestsIncomplete;
 
                                 return shouldBeReported(verifyIsErased, wasErased, isErased);

--- a/src/org/etools/j1939_84/controllers/SectionA5MessageVerifier.java
+++ b/src/org/etools/j1939_84/controllers/SectionA5MessageVerifier.java
@@ -85,9 +85,9 @@ public class SectionA5MessageVerifier {
                                                                 .noneMatch(MonitoredSystemStatus::isComplete);
 
                                 boolean isNoCodes = (p.getActiveCodeCount() == 0
-                                        || p.getActiveCodeCount() == (byte) 0xFF)
-                                        && (p.getPreviouslyActiveCodeCount() == 0
-                                                || p.getPreviouslyActiveCodeCount() == (byte) 0xFF);
+                                        && p.getPreviouslyActiveCodeCount() == 0
+                                        || (p.getActiveCodeCount() == (byte) 0xFF)
+                                                && p.getPreviouslyActiveCodeCount() == (byte) 0xFF);
                                 boolean isErased = isNoCodes && isAllTestsIncomplete;
 
                                 var prev = getLatest(DM5DiagnosticReadinessPacket.class, p.getSourceAddress());
@@ -99,9 +99,9 @@ public class SectionA5MessageVerifier {
                                                                     .noneMatch(MonitoredSystemStatus::isComplete);
 
                                 boolean wasNoCodes = (prev.getActiveCodeCount() == 0
-                                        || prev.getActiveCodeCount() == (byte) 0xFF)
-                                        && (prev.getPreviouslyActiveCodeCount() == 0
-                                                || prev.getPreviouslyActiveCodeCount() == (byte) 0xFF);
+                                        && prev.getPreviouslyActiveCodeCount() == 0)
+                                        || (prev.getActiveCodeCount() == (byte) 0xFF
+                                                && prev.getPreviouslyActiveCodeCount() == (byte) 0xFF);
                                 boolean wasErased = wasNoCodes && wasAllTestsIncomplete;
 
                                 return shouldBeReported(verifyIsErased, wasErased, isErased);


### PR DESCRIPTION
Resolves #844

Allow 0/0 and 0xFF/0xFF when checking for erased data.