### PR TITLE
Fix #823 - Late BAM Response message is inconsistent

### DIFF
--- a/src-test/org/etools/j1939_84/bus/j1939/J1939Test.java
+++ b/src-test/org/etools/j1939_84/bus/j1939/J1939Test.java
@@ -484,7 +484,7 @@ public class J1939Test {
                                                                                                                listener);
         assertEquals(1, response.getPackets().size());
         /* verify there is not a warning. */
-        assertFalse(listener.getResults().matches("(?s).*Warning: Late BAM response.*"));
+        assertFalse(listener.getResults().matches("(?s).*TIMING: Late BAM response.*"));
     }
 
     /**
@@ -534,7 +534,7 @@ public class J1939Test {
         /* verify there is a warning */
         assertTrue(listener.getResults()
                            .matches(
-                                    "(?s).*Warning: Late BAM response:  [\\d:.]+ 18ECFF00 \\[8] 20 11 00 03 FF EC FE 00.*"));
+                                    "(?s).*TIMING: Late BAM response -  [\\d:.]+ 18ECFF00 \\[8] 20 11 00 03 FF EC FE 00.*"));
     }
 
     /**
@@ -586,7 +586,7 @@ public class J1939Test {
         /* verify there is a warning */
         assertTrue(listener.getResults()
                            .matches(
-                                    "(?s).*Warning: Late DS response:  [\\d:.]+ 18ECF900 \\[8] 10 11 00 03 FF EC FE 00.*"));
+                                    "(?s).*TIMING: Late DS response -  [\\d:.]+ 18ECF900 \\[8] 10 11 00 03 FF EC FE 00.*"));
     }
 
     @Test

--- a/src/org/etools/j1939_84/bus/RP1210.java
+++ b/src/org/etools/j1939_84/bus/RP1210.java
@@ -157,7 +157,6 @@ public class RP1210 {
             engine = new Engine(bus);
             return bus;
         } else {
-            // return new RP1210Bus(adapter, address, false);
             return new J1939TP(new RP1210Bus(adapter, address, true));
         }
     }


### PR DESCRIPTION
Resolves #823 - Change the format of the message to start with "TIMING:"  So changed the logging so the timing warning is only incremented when the timing issue actually happens