### PR TITLE
Fix #870 - Don't fail if the DM31 isn't supported

### DIFF
--- a/src-test/org/etools/j1939_84/controllers/part08/Part08Step09ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part08/Part08Step09ControllerTest.java
@@ -169,14 +169,6 @@ public class Part08Step09ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
-        verify(mockListener).addOutcome(PART_NUMBER,
-                                        STEP_NUMBER,
-                                        FAIL,
-                                        "6.8.9.2.a - No ECU reported same DTC as MIL on as reported in DM12 earlier in this part");
-        verify(mockListener).addOutcome(PART_NUMBER,
-                                        STEP_NUMBER,
-                                        FAIL,
-                                        "6.8.9.2.c - No ECU reported same DTC as MIL off as reported in DM23 earlier in this part");
     }
 
     @Test

--- a/src-test/org/etools/j1939_84/controllers/part09/Part09Step13ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part09/Part09Step13ControllerTest.java
@@ -185,7 +185,7 @@ public class Part09Step13ControllerTest extends AbstractControllerTest {
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
                                         FAIL,
-                                        "6.9.13.2.a - Engine #1 (0) reported MIL not off for all reported DTCs");
+                                        "6.9.13.2.a - Engine #1 (0) MIL is not reported off for all reported DTCs");
     }
 
     @Test

--- a/src/org/etools/j1939_84/controllers/part02/Part02Step13Controller.java
+++ b/src/org/etools/j1939_84/controllers/part02/Part02Step13Controller.java
@@ -72,7 +72,7 @@ public class Part02Step13Controller extends StepController {
                  .filter(this::isMilNotOffAndNotAltOff)
                  .map(ParsedPacket::getModuleName)
                  .forEach(moduleName -> {
-                     addFailure("6.2.13.2.a - ECU " + moduleName + " reported MIL not off/alt-off");
+                     addFailure("6.2.13.2.a - " + moduleName + " did not report MIL 'off'");
                  });
 
         // b. Fail if NACK not received from OBD ECUs that did not provide DM31.

--- a/src/org/etools/j1939_84/controllers/part08/Part08Step09Controller.java
+++ b/src/org/etools/j1939_84/controllers/part08/Part08Step09Controller.java
@@ -69,18 +69,20 @@ public class Part08Step09Controller extends StepController {
 
         // 6.8.9.2.a. (if supported) Fail if no ECU reports same DTC as MIL on for as was reported in DM12 earlier
         // in this part.
-        boolean noDM12Match = true;
-        for (DM31DtcToLampAssociation dm31 : packets) {
-            var dtcs = getDM12DTCs(dm31.getSourceAddress());
-            for (DiagnosticTroubleCode dtc : dtcs) {
-                var dtcLampStatus = dm31.findLampStatusForDTC(dtc);
-                if (dtcLampStatus != null && dtcLampStatus.getMalfunctionIndicatorLampStatus() == ON) {
-                    noDM12Match = false;
+        if (!packets.isEmpty()) {
+            boolean noDM12Match = true;
+            for (DM31DtcToLampAssociation dm31 : packets) {
+                var dtcs = getDM12DTCs(dm31.getSourceAddress());
+                for (DiagnosticTroubleCode dtc : dtcs) {
+                    var dtcLampStatus = dm31.findLampStatusForDTC(dtc);
+                    if (dtcLampStatus != null && dtcLampStatus.getMalfunctionIndicatorLampStatus() == ON) {
+                        noDM12Match = false;
+                    }
                 }
             }
-        }
-        if (noDM12Match) {
-            addFailure("6.8.9.2.a - No ECU reported same DTC as MIL on as reported in DM12 earlier in this part");
+            if (noDM12Match) {
+                addFailure("6.8.9.2.a - No ECU reported same DTC as MIL on as reported in DM12 earlier in this part");
+            }
         }
 
         // 6.8.9.2.b. (if supported) Fail if any ECU reports additional or fewer DTCs than those reported in DM12 and
@@ -97,18 +99,20 @@ public class Part08Step09Controller extends StepController {
 
         // 6.8.9.2.c. (if supported) Fail if no ECU reports the same DTC as MIL off for the previous active DTC reported
         // in DM23 earlier in this part.
-        boolean noDM23Match = true;
-        for (DM31DtcToLampAssociation dm31 : packets) {
-            var dtcs = getDM23DTCs(dm31.getSourceAddress());
-            for (DiagnosticTroubleCode dtc : dtcs) {
-                var dtcLampStatus = dm31.findLampStatusForDTC(dtc);
-                if (dtcLampStatus != null && dtcLampStatus.getMalfunctionIndicatorLampStatus() == OFF) {
-                    noDM23Match = false;
+        if (!packets.isEmpty()) {
+            boolean noDM23Match = true;
+            for (DM31DtcToLampAssociation dm31 : packets) {
+                var dtcs = getDM23DTCs(dm31.getSourceAddress());
+                for (DiagnosticTroubleCode dtc : dtcs) {
+                    var dtcLampStatus = dm31.findLampStatusForDTC(dtc);
+                    if (dtcLampStatus != null && dtcLampStatus.getMalfunctionIndicatorLampStatus() == OFF) {
+                        noDM23Match = false;
+                    }
                 }
             }
-        }
-        if (noDM23Match) {
-            addFailure("6.8.9.2.c - No ECU reported same DTC as MIL off as reported in DM23 earlier in this part");
+            if (noDM23Match) {
+                addFailure("6.8.9.2.c - No ECU reported same DTC as MIL off as reported in DM23 earlier in this part");
+            }
         }
     }
 

--- a/src/org/etools/j1939_84/controllers/part09/Part09Step13Controller.java
+++ b/src/org/etools/j1939_84/controllers/part09/Part09Step13Controller.java
@@ -83,7 +83,7 @@ public class Part09Step13Controller extends StepController {
                    .filter(s -> s.getMalfunctionIndicatorLampStatus() != OFF)
                    .map(s -> Lookup.getAddressName(address))
                    .forEach(moduleName -> {
-                       addFailure("6.9.13.2.a - " + moduleName + " reported MIL not off for all reported DTCs");
+                       addFailure("6.9.13.2.a - " + moduleName + " MIL is not reported off for all reported DTCs");
                    });
         }
 


### PR DESCRIPTION
Resolves #870 - Part 8 Step 9, when the DM31 isn't supported, don't report failures