### PR TITLE
#815 - Update the Help file to link to a bug reporting URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,26 +7,9 @@ in accordance with the diagnostic messages specified in SAE J1939-73, to fulfill
 requirements contained in various government regulations, including the HD OBD regulations by US EPA and California’s
 Air Resources Board (ARB).
 
-## Future Enhancements
+## Reporting an issue
 
-* Part 1 Step 3 Fails if _any_ module reports a different OBD Compliance Value
-    * Currently, the tool will report a failure if any module doesn't report the same OBD Compliance Value that other
-      modules report. The intent is for all "OBD" modules to report the same OBD Compliance Values. The documentation
-      needs updating to clarify this.
-    * https://github.com/battjt/j1939-84/issues/515
-    * https://github.com/battjt/j1939-84/issues/531
+If you discover an problem with the tool or have a suggestion for improvement, please consider submitting a issue.
 
-
-* Part 1 Step 26 Handling distributed providers
-    * One module (such as the Engine), may claim support for a particular SP (such as Fuel Level), but then return
-      "not available" for that SP. The design of the vehicle intends for another OBD? module to provide the SP's value.
-      Guidance needs to be provided on how to handle this.
-    * https://github.com/battjt/j1939-84/issues/497
-
-
-* Part 1 Step 26 Doesn't check for on request SPs which are not supported
-    * SP which are not supported by a module in DM24 and that are sent on request, are not checked by the tool.  
-      That is the tool won't request the PG to see the module does support an SP which is required to be supported
-      according to Table A-1
-    * https://github.com/battjt/j1939-84/issues/525
-    
+You can log in to Github and create a new issue, or you can submit an issue anonymously
+here: https://gitreports.com/issue/battjt/j1939-84  

--- a/src/org/etools/j1939_84/resources/Help.html
+++ b/src/org/etools/j1939_84/resources/Help.html
@@ -6,6 +6,22 @@
 
 </head>
 <body lang="en-US" style="direction: ltr;">
-<h1>J1939-84 Tool User Documentation Help File</h1>
+<h1>Soon to be the J1939-84 Tool User Documentation Help</h1>
+
+<p>
+    Thank you for testing the beta version of the SAE J1939-84 Tool V3.
+</p>
+<p>
+    We hope you find this tool easier to use than previous versions and bug free.
+    However, even though we are software developers, we aren't perfect.
+    Please consider submitting a bug report so we can improve this tool.
+</p>
+<p>
+    Additionally, if you have a suggestion for improvement, please let us know.
+    We are planning future updates soon and would be happy to consider all ideas for the next release.
+</p>
+<p>
+    <a href="https://gitreports.com/issue/battjt/j1939-84">Click here to submit a bug or suggestion</a>
+</p>
 </body>
 </html>


### PR DESCRIPTION
This is the help screen:

![Screen Shot 2021-03-23 at 9 29 53 PM](https://user-images.githubusercontent.com/7874086/112240737-3ec67380-8c1f-11eb-8bed-dba5b8bc66ec.png)

The link takes the user to [https://gitreports.com/issue/battjt/j1939-84](https://gitreports.com/issue/battjt/j1939-84)
