### PR TITLE
Fix #891 - FB00h is status and not scalable to Engineering Value

### DIFF
--- a/src-test/org/etools/j1939_84/bus/j1939/packets/SlotTest.java
+++ b/src-test/org/etools/j1939_84/bus/j1939/packets/SlotTest.java
@@ -116,11 +116,19 @@ public class SlotTest {
         assertEquals("Not Available", slot.asString(data));
         assertTrue(slot.isNotAvailable(data));
         assertFalse(slot.isError(data));
+        assertFalse(slot.isFB(data));
 
         data = new byte[] { (byte) 0xFE };
         assertEquals("Error", slot.asString(data));
         assertFalse(slot.isNotAvailable(data));
         assertTrue(slot.isError(data));
+        assertFalse(slot.isFB(data));
+
+        data = new byte[] { (byte) 0xFB };
+        assertEquals("0xFB", slot.asString(data));
+        assertFalse(slot.isNotAvailable(data));
+        assertFalse(slot.isError(data));
+        assertTrue(slot.isFB(data));
     }
 
     @Test
@@ -192,11 +200,19 @@ public class SlotTest {
         assertEquals("Not Available", slot.asString(data));
         assertTrue(slot.isNotAvailable(data));
         assertFalse(slot.isError(data));
+        assertFalse(slot.isFB(data));
 
         data = new byte[] { (byte) 0x00, (byte) 0xFE };
         assertEquals("Error", slot.asString(data));
         assertFalse(slot.isNotAvailable(data));
         assertTrue(slot.isError(data));
+        assertFalse(slot.isFB(data));
+
+        data = new byte[] { (byte) 0x00, (byte) 0xFB };
+        assertEquals("0xFB00", slot.asString(data));
+        assertFalse(slot.isNotAvailable(data));
+        assertFalse(slot.isError(data));
+        assertTrue(slot.isFB(data));
     }
 
     @Test
@@ -254,6 +270,13 @@ public class SlotTest {
         assertEquals("Error", slot.asString(data));
         assertFalse(slot.isNotAvailable(data));
         assertTrue(slot.isError(data));
+        assertFalse(slot.isFB(data));
+
+        data = new byte[] { (byte) 0x00, (byte) 0x00, (byte) 0xFB };
+        assertEquals("0xFB0000", slot.asString(data));
+        assertFalse(slot.isNotAvailable(data));
+        assertFalse(slot.isError(data));
+        assertTrue(slot.isFB(data));
     }
 
     @Test
@@ -288,11 +311,19 @@ public class SlotTest {
         assertEquals("Not Available", slot.asString(data));
         assertTrue(slot.isNotAvailable(data));
         assertFalse(slot.isError(data));
+        assertFalse(slot.isFB(data));
 
         data = new byte[] { (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0xFE };
         assertEquals("Error", slot.asString(data));
         assertFalse(slot.isNotAvailable(data));
         assertTrue(slot.isError(data));
+        assertFalse(slot.isFB(data));
+
+        data = new byte[] { (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0xFB };
+        assertEquals("0xFB000000", slot.asString(data));
+        assertFalse(slot.isNotAvailable(data));
+        assertFalse(slot.isError(data));
+        assertTrue(slot.isFB(data));
     }
 
     @Test

--- a/src/org/etools/j1939_84/bus/j1939/packets/Slot.java
+++ b/src/org/etools/j1939_84/bus/j1939/packets/Slot.java
@@ -70,6 +70,10 @@ public class Slot {
             return "Error";
         }
 
+        if (isFB(data)) {
+            return String.format("0x%X", value);
+        }
+
         String printedValue = String.format("%f", scale(value));
         if (unit != null) {
             return printedValue + " " + unit;
@@ -97,7 +101,7 @@ public class Slot {
             return Long.valueOf(value).doubleValue();
         }
 
-        if (isNotAvailable(data) || isError(data)) {
+        if (isNotAvailable(data) || isError(data) || isFB(data)) {
             return null;
         }
 
@@ -179,6 +183,19 @@ public class Slot {
         long error = ((long) 0xFE) << (length - 8);
         long maskedValue = value & mask;
         return maskedValue == error;
+    }
+
+    public boolean isFB(byte[] data) {
+        if (length == 1 || isAscii() || data.length == 0) {
+            return false;
+        }
+
+        long value = toValue(data);
+
+        long mask = ((long) 0xFF) << (length - 8);
+        long fb = ((long) 0xFB) << (length - 8);
+        long maskedValue = value & mask;
+        return maskedValue == fb;
     }
 
     public boolean isNotAvailable(byte[] data) {


### PR DESCRIPTION
Resolves #891 

Check for FB as a value.  Don't use it to check for plausibility.  Display as "0xFB[00]" as each parameter has a special definition for it.