### PR TITLE
Fix #918 - Update keystate logging 

### DIFF
--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step02ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step02ControllerTest.java
@@ -145,8 +145,6 @@ public class Part01Step02ControllerTest extends AbstractControllerTest {
         verify(engineSpeedModule, atLeastOnce()).getEngineSpeedAsString();
         verify(engineSpeedModule, atLeastOnce()).getKeyState();
 
-        assertEquals("Step 6.1.2.2.a - Waiting for key on with engine off", listener.getMessages());
-
         String expectedResults = "";
         expectedResults += "Initial Engine Speed = 0.0 RPMs" + NL;
         expectedResults += "Final Engine Speed = 0.0 RPMs" + NL;

--- a/src-test/org/etools/j1939_84/controllers/part02/Part02Step01ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part02/Part02Step01ControllerTest.java
@@ -146,8 +146,7 @@ public class Part02Step01ControllerTest extends AbstractControllerTest {
         verify(engineSpeedModule, atLeastOnce()).getEngineSpeedAsString();
         verify(engineSpeedModule, atLeastOnce()).getKeyState();
 
-        String expectedMessages = "Step 6.2.1.1.a - Waiting for engine start";
-        assertEquals(expectedMessages, listener.getMessages());
+        assertEquals("", listener.getMessages());
 
         String expectedResults = "Initial Engine Speed = 0.0 RPMs" + NL;
         expectedResults += "Final Engine Speed = 0.0 RPMs" + NL;

--- a/src-test/org/etools/j1939_84/controllers/part02/Part02Step18ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part02/Part02Step18ControllerTest.java
@@ -230,8 +230,7 @@ public class Part02Step18ControllerTest extends AbstractControllerTest {
 
         verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, ABORT, "User cancelled testing at Part 2 Step 18");
 
-        String expectedMessages = "Step 6.2.18.1.a - Waiting for key off" + NL;
-        expectedMessages += "Step 6.2.18.1.b - Waiting for implant of Fault A according to the engine manufacturer's instruction"
+        String expectedMessages = "Step 6.2.18.1.b - Waiting for implant of Fault A according to the engine manufacturer's instruction"
                 + NL;
         expectedMessages += "Step 6.2.18.1.c - Waiting for engine start" + NL;
         expectedMessages += "User cancelled testing at Part 2 Step 18";

--- a/src-test/org/etools/j1939_84/controllers/part03/Part03Step01ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part03/Part03Step01ControllerTest.java
@@ -140,8 +140,7 @@ public class Part03Step01ControllerTest extends AbstractControllerTest {
         verify(engineSpeedModule, atLeastOnce()).getEngineSpeedAsString();
         verify(engineSpeedModule, atLeastOnce()).getKeyState();
 
-        String expectedMessages = "Step 6.3.1.2.a - Waiting for engine start";
-        assertEquals(expectedMessages, listener.getMessages());
+        assertEquals("", listener.getMessages());
 
         String expectedResults = "";
         expectedResults += "Initial Engine Speed = 0.0 RPMs" + NL;

--- a/src-test/org/etools/j1939_84/controllers/part04/Part04Step01ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part04/Part04Step01ControllerTest.java
@@ -140,7 +140,7 @@ public class Part04Step01ControllerTest extends AbstractControllerTest {
         verify(engineSpeedModule, atLeastOnce()).getEngineSpeedAsString();
         verify(engineSpeedModule, atLeastOnce()).getKeyState();
 
-        assertEquals("Step 6.4.1.2.a - Waiting for engine start", listener.getMessages());
+        assertEquals("", listener.getMessages());
 
         String expectedResults = "";
         expectedResults += "Initial Engine Speed = 0.0 RPMs" + NL;

--- a/src-test/org/etools/j1939_84/controllers/part05/Part05Step01ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part05/Part05Step01ControllerTest.java
@@ -140,7 +140,7 @@ public class Part05Step01ControllerTest extends AbstractControllerTest {
         verify(engineSpeedModule, atLeastOnce()).getEngineSpeedAsString();
         verify(engineSpeedModule, atLeastOnce()).getKeyState();
 
-        assertEquals("Step 6.5.1.2.a - Waiting for engine start", listener.getMessages());
+        assertEquals("", listener.getMessages());
 
         String expectedResults = "";
         expectedResults += "Initial Engine Speed = 0.0 RPMs" + NL;

--- a/src-test/org/etools/j1939_84/controllers/part05/Part05Step07ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part05/Part05Step07ControllerTest.java
@@ -179,13 +179,9 @@ public class Part05Step07ControllerTest extends AbstractControllerTest {
                                              questionCaptor.capture());
         questionCaptor.getValue().answered(YES);
 
-        String expectedMessages = "Step 6.5.7.1.a - Waiting for key off" + NL +
-                "Step 6.5.7.1.b - Waiting manufacturer’s recommended interval with the key off" + NL +
-                "Step 6.5.7.1.c - Waiting for engine start" + NL +
+        String expectedMessages = "Step 6.5.7.1.b - Waiting manufacturer’s recommended interval with the key off" + NL +
                 "Step 6.5.7.1.d - Waiting manufacturer’s recommended time for Fault A to be detected as passed" + NL +
-                "Step 6.5.7.1.e - Waiting for key off" + NL +
                 "Step 6.5.7.1.f - Waiting manufacturer’s recommended interval with the key off" + NL +
-                "Step 6.5.7.1.g - Waiting for engine start" + NL +
                 "Step 6.5.7.1.h - Waiting manufacturer’s recommended time for Fault A to be detected as passed";
         assertEquals(expectedMessages, listener.getMessages());
 

--- a/src-test/org/etools/j1939_84/controllers/part06/Part06Step01ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part06/Part06Step01ControllerTest.java
@@ -138,7 +138,7 @@ public class Part06Step01ControllerTest extends AbstractControllerTest {
         verify(engineSpeedModule, atLeastOnce()).getEngineSpeedAsString();
         verify(engineSpeedModule, atLeastOnce()).getKeyState();
 
-        assertEquals("Step 6.6.1.2.a - Waiting for engine start", listener.getMessages());
+        assertEquals("", listener.getMessages());
 
         String expectedResults = "";
         expectedResults += "Initial Engine Speed = 0.0 RPMs" + NL;

--- a/src-test/org/etools/j1939_84/controllers/part07/Part07Step01ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part07/Part07Step01ControllerTest.java
@@ -138,7 +138,7 @@ public class Part07Step01ControllerTest extends AbstractControllerTest {
         verify(engineSpeedModule, atLeastOnce()).getEngineSpeedAsString();
         verify(engineSpeedModule, atLeastOnce()).getKeyState();
 
-        assertEquals("Step 6.7.1.2.a - Waiting for key on with engine off", listener.getMessages());
+        assertEquals("", listener.getMessages());
 
         String expectedResults = "";
         expectedResults += "Initial Engine Speed = 0.0 RPMs" + NL;

--- a/src-test/org/etools/j1939_84/controllers/part08/Part08Step01ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part08/Part08Step01ControllerTest.java
@@ -138,7 +138,7 @@ public class Part08Step01ControllerTest extends AbstractControllerTest {
         verify(engineSpeedModule, atLeastOnce()).getEngineSpeedAsString();
         verify(engineSpeedModule, atLeastOnce()).getKeyState();
 
-        assertEquals("Step 6.8.1.2.a - Waiting for engine start", listener.getMessages());
+        assertEquals("", listener.getMessages());
 
         String expectedResults = "";
         expectedResults += "Initial Engine Speed = 0.0 RPMs" + NL;

--- a/src-test/org/etools/j1939_84/controllers/part09/Part09Step01ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part09/Part09Step01ControllerTest.java
@@ -138,7 +138,7 @@ public class Part09Step01ControllerTest extends AbstractControllerTest {
         verify(engineSpeedModule, atLeastOnce()).getEngineSpeedAsString();
         verify(engineSpeedModule, atLeastOnce()).getKeyState();
 
-        assertEquals("Step 6.9.1.2.a - Waiting for key on with engine off", listener.getMessages());
+        assertEquals("", listener.getMessages());
 
         String expectedResults = "";
         expectedResults += "Initial Engine Speed = 0.0 RPMs" + NL;

--- a/src-test/org/etools/j1939_84/controllers/part10/Part10Step01ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part10/Part10Step01ControllerTest.java
@@ -138,8 +138,7 @@ public class Part10Step01ControllerTest extends AbstractControllerTest {
         verify(engineSpeedModule, atLeastOnce()).getEngineSpeedAsString();
         verify(engineSpeedModule, atLeastOnce()).getKeyState();
 
-        String expectedMessages = "Step 6.10.1.2.a - Waiting for engine start";
-        assertEquals(expectedMessages, listener.getMessages());
+        assertEquals("", listener.getMessages());
 
         String expectedResults = "";
         expectedResults += "Initial Engine Speed = 0.0 RPMs" + NL;

--- a/src-test/org/etools/j1939_84/controllers/part10/Part10Step03ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part10/Part10Step03ControllerTest.java
@@ -138,8 +138,7 @@ public class Part10Step03ControllerTest extends AbstractControllerTest {
         verify(engineSpeedModule, atLeastOnce()).getEngineSpeedAsString();
         verify(engineSpeedModule, atLeastOnce()).getKeyState();
 
-        String expectedMessages = "Step 6.10.3.2.a - Waiting for engine start";
-        assertEquals(expectedMessages, listener.getMessages());
+        assertEquals("", listener.getMessages());
 
         String expectedResults = "";
         expectedResults += "Initial Engine Speed = 0.0 RPMs" + NL;

--- a/src-test/org/etools/j1939_84/controllers/part11/Part11Step01ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part11/Part11Step01ControllerTest.java
@@ -137,7 +137,7 @@ public class Part11Step01ControllerTest extends AbstractControllerTest {
         verify(engineSpeedModule, atLeastOnce()).getEngineSpeedAsString();
         verify(engineSpeedModule, atLeastOnce()).getKeyState();
 
-        assertEquals("Step 6.11.1.2.a - Waiting for engine start", listener.getMessages());
+        assertEquals("", listener.getMessages());
 
         String expectedResults = "";
         expectedResults += "Initial Engine Speed = 0.0 RPMs" + NL;

--- a/src-test/org/etools/j1939_84/controllers/part12/Part12Step01ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part12/Part12Step01ControllerTest.java
@@ -137,10 +137,9 @@ public class Part12Step01ControllerTest extends AbstractControllerTest {
         verify(engineSpeedModule, atLeastOnce()).getEngineSpeedAsString();
         verify(engineSpeedModule, atLeastOnce()).getKeyState();
 
-        assertEquals("Step 6.12.1.2.a - Waiting for key on with engine off", listener.getMessages());
+        assertEquals("", listener.getMessages());
 
-        String expectedResults = "";
-        expectedResults += "Initial Engine Speed = 0.0 RPMs" + NL;
+        String expectedResults = "Initial Engine Speed = 0.0 RPMs" + NL;
         expectedResults += "Final Engine Speed = 0.0 RPMs" + NL;
         assertEquals(expectedResults, listener.getResults());
     }

--- a/src/org/etools/j1939_84/controllers/StepController.java
+++ b/src/org/etools/j1939_84/controllers/StepController.java
@@ -136,9 +136,8 @@ public abstract class StepController extends Controller {
     protected void ensureKeyStateIs(KeyState requestedKeyState, String section) throws InterruptedException {
         getListener().onResult("Initial Engine Speed = " + getEngineSpeedAsString());
 
-        updateProgress("Step " + section + " - " + getWaitingKeyStateAsString(requestedKeyState));
-
         if (getCurrentKeyState() != requestedKeyState) {
+            updateProgress("Step " + section + " - " + getWaitingKeyStateAsString(requestedKeyState));
             if (!isDevEnv()) {
                 getListener().onUrgentMessage(getCurrentKeyStateAsString(requestedKeyState),
                                               "Step " + section,


### PR DESCRIPTION
Fix logging to correctly printout when the kestates are actually different.  We were logging regardless of the current state which leads to confusion.