### PR TITLE
Fix #921 - Enhanced handling of DM26 enabled and status values

### DIFF
--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step14ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step14ControllerTest.java
@@ -130,7 +130,7 @@ public class Part01Step14ControllerTest extends AbstractControllerTest {
         verify(diagnosticMessageModule).setJ1939(j1939);
         verify(diagnosticMessageModule).requestDM26(any());
 
-        verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL, "6.1.14.2.f - No OBD ECU provided DM26");
+        verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL, "6.1.14.2.e - No OBD ECU provided DM26");
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -199,27 +199,22 @@ public class Part01Step14ControllerTest extends AbstractControllerTest {
                                         1,
                                         14,
                                         FAIL,
-                                        "6.1.14.2.c - Transmission #1 (3) response indicates support for monitor Comprehensive component in DM5 but is reported as not enabled by DM26 response");
-        verify(mockListener).addOutcome(
-                                        1,
-                                        14,
-                                        FAIL,
                                         "6.1.14.2.b - Transmission #1 (3) response for a monitor Heated catalyst in DM5 is reported as not supported and is reported as enabled by DM26 response");
         verify(mockListener).addOutcome(
                                         1,
                                         14,
                                         FAIL,
-                                        "6.1.14.2.d - Engine #2 (1) response indicates number of warm-ups since code clear is not zero");
+                                        "6.1.14.2.c - Engine #2 (1) response indicates number of warm-ups since code clear is not zero");
         verify(mockListener).addOutcome(
                                         1,
                                         14,
                                         FAIL,
-                                        "6.1.14.2.d - Transmission #1 (3) response indicates number of warm-ups since code clear is not zero");
+                                        "6.1.14.2.c - Transmission #1 (3) response indicates number of warm-ups since code clear is not zero");
         verify(mockListener).addOutcome(
                                         1,
                                         14,
                                         FAIL,
-                                        "6.1.14.2.e - Engine #2 (1) response indicates time since engine start is not zero");
+                                        "6.1.14.2.d - Engine #2 (1) response indicates time since engine start is not zero");
         verify(mockListener).addOutcome(
                                         1,
                                         14,

--- a/src-test/org/etools/j1939_84/controllers/part02/Part02Step08ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part02/Part02Step08ControllerTest.java
@@ -155,7 +155,7 @@ public class Part02Step08ControllerTest extends AbstractControllerTest {
         verify(mockListener).addOutcome(PART,
                                         STEP,
                                         INFO,
-                                        "6.2.8.5 - No responses received from Engine #2 (1)");
+                                        "6.2.8.5.a - No responses received from Engine #2 (1)");
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
@@ -267,7 +267,7 @@ public class Part02Step08ControllerTest extends AbstractControllerTest {
                                         2,
                                         8,
                                         FAIL,
-                                        "6.2.8.2.a - Difference from Turbocharger (2) regarding readiness status this cycle compared to responses in part 1 after DM11.");
+                                        "6.2.8.2.a - Difference from Turbocharger (2) monitor support bits this cycle compared to responses in part 1 after DM11");
         verify(mockListener).addOutcome(
                                         2,
                                         8,
@@ -277,7 +277,7 @@ public class Part02Step08ControllerTest extends AbstractControllerTest {
                                         2,
                                         8,
                                         FAIL,
-                                        "6.2.8.2.a - Difference from Engine #1 (0) regarding readiness status this cycle compared to responses in part 1 after DM11.");
+                                        "6.2.8.2.a - Difference from Engine #1 (0) monitor support bits this cycle compared to responses in part 1 after DM11");
         verify(mockListener).addOutcome(
                                         2,
                                         8,
@@ -362,7 +362,7 @@ public class Part02Step08ControllerTest extends AbstractControllerTest {
                                         2,
                                         8,
                                         INFO,
-                                        "6.2.8.5 - No responses received from Transmission #1 (3)");
+                                        "6.2.8.5.a - No responses received from Transmission #1 (3)");
 
     }
 

--- a/src-test/org/etools/j1939_84/controllers/part11/Part11Step11ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part11/Part11Step11ControllerTest.java
@@ -3,6 +3,7 @@
  */
 package org.etools.j1939_84.controllers.part11;
 
+import static org.etools.j1939_84.J1939_84.NL;
 import static org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket.Response.NACK;
 import static org.etools.j1939_84.model.Outcome.FAIL;
 import static org.junit.Assert.assertEquals;
@@ -153,7 +154,27 @@ public class Part11Step11ControllerTest extends AbstractControllerTest {
 
         assertEquals(9.0, dataRepository.getObdModule(0).getDeltaEngineStart(), 0.0);
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getResults());
+
+        String expected = "" + NL;
+        expected += "Vehicle Composite of DM26:" + NL;
+        expected += "    A/C system refrigerant     not enabled, not complete" + NL;
+        expected += "    Boost pressure control sys not enabled, not complete" + NL;
+        expected += "    Catalyst                   not enabled, not complete" + NL;
+        expected += "    Cold start aid system      not enabled, not complete" + NL;
+        expected += "    Comprehensive component    not enabled, not complete" + NL;
+        expected += "    Diesel Particulate Filter  not enabled, not complete" + NL;
+        expected += "    EGR/VVT system             not enabled, not complete" + NL;
+        expected += "    Evaporative system         not enabled, not complete" + NL;
+        expected += "    Exhaust Gas Sensor         not enabled, not complete" + NL;
+        expected += "    Exhaust Gas Sensor heater  not enabled, not complete" + NL;
+        expected += "    Fuel System                not enabled, not complete" + NL;
+        expected += "    Heated catalyst            not enabled, not complete" + NL;
+        expected += "    Misfire                    not enabled, not complete" + NL;
+        expected += "    NMHC converting catalyst   not enabled, not complete" + NL;
+        expected += "    NOx catalyst/adsorber      not enabled, not complete" + NL;
+        expected += "    Secondary air system       not enabled, not complete" + NL;
+        assertEquals(expected, listener.getResults());
+
         assertEquals(List.of(), listener.getOutcomes());
     }
 
@@ -170,7 +191,26 @@ public class Part11Step11ControllerTest extends AbstractControllerTest {
         verify(diagnosticMessageModule).requestDM26(any(), eq(0));
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getResults());
+        String expected = "" + NL;
+        expected += "Vehicle Composite of DM26:" + NL;
+        expected += "    A/C system refrigerant     not enabled, not complete" + NL;
+        expected += "    Boost pressure control sys not enabled, not complete" + NL;
+        expected += "    Catalyst                   not enabled, not complete" + NL;
+        expected += "    Cold start aid system      not enabled, not complete" + NL;
+        expected += "    Comprehensive component    not enabled, not complete" + NL;
+        expected += "    Diesel Particulate Filter  not enabled, not complete" + NL;
+        expected += "    EGR/VVT system             not enabled, not complete" + NL;
+        expected += "    Evaporative system         not enabled, not complete" + NL;
+        expected += "    Exhaust Gas Sensor         not enabled, not complete" + NL;
+        expected += "    Exhaust Gas Sensor heater  not enabled, not complete" + NL;
+        expected += "    Fuel System                not enabled, not complete" + NL;
+        expected += "    Heated catalyst            not enabled, not complete" + NL;
+        expected += "    Misfire                    not enabled, not complete" + NL;
+        expected += "    NMHC converting catalyst   not enabled, not complete" + NL;
+        expected += "    NOx catalyst/adsorber      not enabled, not complete" + NL;
+        expected += "    Secondary air system       not enabled, not complete" + NL;
+        assertEquals(expected, listener.getResults());
+
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
                                         FAIL,
@@ -193,7 +233,27 @@ public class Part11Step11ControllerTest extends AbstractControllerTest {
         verify(diagnosticMessageModule).requestDM26(any(), eq(0));
 
         assertEquals("", listener.getMessages());
-        assertEquals("", listener.getResults());
+
+        String expected = "" + NL;
+        expected += "Vehicle Composite of DM26:" + NL;
+        expected += "    A/C system refrigerant     not enabled, not complete" + NL;
+        expected += "    Boost pressure control sys not enabled, not complete" + NL;
+        expected += "    Catalyst                   not enabled, not complete" + NL;
+        expected += "    Cold start aid system      not enabled, not complete" + NL;
+        expected += "    Comprehensive component    not enabled, not complete" + NL;
+        expected += "    Diesel Particulate Filter  not enabled, not complete" + NL;
+        expected += "    EGR/VVT system             not enabled, not complete" + NL;
+        expected += "    Evaporative system         not enabled, not complete" + NL;
+        expected += "    Exhaust Gas Sensor         not enabled, not complete" + NL;
+        expected += "    Exhaust Gas Sensor heater  not enabled, not complete" + NL;
+        expected += "    Fuel System                not enabled, not complete" + NL;
+        expected += "    Heated catalyst            not enabled, not complete" + NL;
+        expected += "    Misfire                    not enabled, not complete" + NL;
+        expected += "    NMHC converting catalyst   not enabled, not complete" + NL;
+        expected += "    NOx catalyst/adsorber      not enabled, not complete" + NL;
+        expected += "    Secondary air system       not enabled, not complete" + NL;
+        assertEquals(expected, listener.getResults());
+
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
                                         FAIL,
@@ -212,6 +272,7 @@ public class Part11Step11ControllerTest extends AbstractControllerTest {
 
         assertEquals("", listener.getMessages());
         assertEquals("", listener.getResults());
+
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
                                         FAIL,

--- a/src-test/org/etools/j1939_84/controllers/part12/Part12Step02ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part12/Part12Step02ControllerTest.java
@@ -279,10 +279,6 @@ public class Part12Step02ControllerTest extends AbstractControllerTest {
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
                                         FAIL,
-                                        "6.12.2.2.a - Engine #1 (0) reported Misfire as 'not complete this cycle' when it reported it as 'complete this cycle' in part 11");
-        verify(mockListener).addOutcome(PART_NUMBER,
-                                        STEP_NUMBER,
-                                        FAIL,
                                         "6.12.2.2.a - Engine #1 (0) reported NMHC converting catalyst as 'not complete this cycle' when it reported it as 'complete this cycle' in part 11");
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,

--- a/src/org/etools/j1939_84/controllers/part01/Part01Step14Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step14Controller.java
@@ -71,9 +71,9 @@ public class Part01Step14Controller extends StepController {
                                                         .filter(p -> isObdModule(p.getSourceAddress()))
                                                         .collect(Collectors.toList());
 
-        // 6.1.14.2.f. Fail if no OBD ECU provides DM26.
+        // 6.1.14.2.e. Fail if no OBD ECU provides DM26.
         if (globalPackets.isEmpty()) {
-            addFailure("6.1.14.2.f - No OBD ECU provided DM26");
+            addFailure("6.1.14.2.e - No OBD ECU provided DM26");
         } else {
             // 6.1.14.1.a.i. Create list by ECU address of all data and current status for use later in the test.
             globalPackets.forEach(this::save);
@@ -102,14 +102,7 @@ public class Part01Step14Controller extends StepController {
                          if (dm5System != null) {
                              boolean dm5SystemEnabled = dm5System.getStatus().isEnabled();
                              if (!dm26SystemEnabled && dm5SystemEnabled) {
-                                 if (dm26System.getId() == CompositeSystem.COMPREHENSIVE_COMPONENT) {
-                                     // 6.1.14.2.c. Fail if any response from an ECU indicating support for CCM
-                                     // monitor in DM5 report '0=monitor disabled for rest of this cycle or not
-                                     // supported' in SPN 3303 bit 3.
-                                     addFailure("6.1.14.2.c - " + moduleName
-                                             + " response indicates support for monitor " + systemName
-                                             + " in DM5 but is reported as not enabled by DM26 response");
-                                 } else {
+                                 if (dm26System.getId() != CompositeSystem.COMPREHENSIVE_COMPONENT) {
                                      // 6.1.14.2.a. Fail if any response for any monitor supported in
                                      // DM5 by a given ECU is reported as '0=monitor complete
                                      // this cycle or not supported' in SPN 3303 bits 1-4 and
@@ -125,31 +118,29 @@ public class Part01Step14Controller extends StepController {
                                  // reported in DM26 as '0=monitor complete this
                                  // cycle or not supported' in SPN 3303 bits 5-7 and
                                  // '0=monitor disabled for rest of this cycle or not
-                                 // supported' in SPN 3303 bits 1-2 and SPN 3304.20
-                                 addFailure(
-                                            "6.1.14.2.b - " + moduleName + " response for a monitor "
+                                 // supported' in SPN 3303 bits 1-2 and SPN 3304.
+                                 addFailure("6.1.14.2.b - " + moduleName + " response for a monitor "
                                                     + systemName
                                                     + " in DM5 is reported as not supported and is reported as enabled by DM26 response");
                              }
                          }
                      });
 
-        // 6.1.14.2.d. Fail if any response indicates number of warm-ups since code clear (WU-SCC) (SPN 3302) is not
-        // zero.
+        // 6.1.14.2.c. Fail if any response indicates number of warm-ups since code clear (SPN 3302) is not zero.
         globalPackets.stream()
                      .filter(packet -> packet.getWarmUpsSinceClear() != 0)
                      .map(ParsedPacket::getModuleName)
                      .forEach(moduleName -> {
-                         addFailure("6.1.14.2.d - " + moduleName
+                         addFailure("6.1.14.2.c - " + moduleName
                                  + " response indicates number of warm-ups since code clear is not zero");
                      });
 
-        // 6.1.14.2.e. Fail if any response indicates time since engine start (SPN 3301) is not zero.
+        // 6.1.14.2.d. Fail if any response indicates time since engine start (SPN 3301) is not zero.
         globalPackets.stream()
                      .filter(packet -> packet.getTimeSinceEngineStart() != 0)
                      .map(ParsedPacket::getModuleName)
                      .forEach(moduleName -> {
-                         addFailure("6.1.14.2.e - " + moduleName
+                         addFailure("6.1.14.2.d - " + moduleName
                                  + " response indicates time since engine start is not zero");
                      });
 

--- a/src/org/etools/j1939_84/controllers/part11/Part11Step11Controller.java
+++ b/src/org/etools/j1939_84/controllers/part11/Part11Step11Controller.java
@@ -3,12 +3,15 @@
  */
 package org.etools.j1939_84.controllers.part11;
 
+import static org.etools.j1939_84.modules.DiagnosticMessageModule.getCompositeSystems;
+
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
 import org.etools.j1939_84.bus.j1939.packets.DM26TripDiagnosticReadinessPacket;
+import org.etools.j1939_84.bus.j1939.packets.MonitoredSystem;
 import org.etools.j1939_84.bus.j1939.packets.ParsedPacket;
 import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.StepController;
@@ -95,6 +98,16 @@ public class Part11Step11Controller extends StepController {
         // trip or supported and not complete this trip).
         // This is out of order to prevent overwriting previous data before use.
         packets.forEach(this::save);
+
+        // 6.11.11.1.c. Display composite status for support and enable bits for responses received from OBD ECUs.
+        if (!packets.isEmpty()) {
+            getListener().onResult("");
+            getListener().onResult("Vehicle Composite of DM26:");
+            getCompositeSystems(packets, false).stream()
+                                               .sorted()
+                                               .map(MonitoredSystem::toString)
+                                               .forEach(s -> getListener().onResult(s));
+        }
     }
 
     private boolean areTimesConsistent(DM26TripDiagnosticReadinessPacket currentPacket) {

--- a/src/org/etools/j1939_84/controllers/part12/Part12Step02Controller.java
+++ b/src/org/etools/j1939_84/controllers/part12/Part12Step02Controller.java
@@ -3,6 +3,9 @@
  */
 package org.etools.j1939_84.controllers.part12;
 
+import static org.etools.j1939_84.bus.j1939.packets.CompositeSystem.COMPREHENSIVE_COMPONENT;
+import static org.etools.j1939_84.bus.j1939.packets.CompositeSystem.MISFIRE;
+
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
@@ -68,8 +71,8 @@ public class Part12Step02Controller extends StepController {
         var packets = filterRequestResultPackets(dsResults);
         packets.forEach(this::save);
 
-        // 6.12.2.2.a. Fail if any supported monitor (except CCM) that was “0 = complete this cycle” in part 11 is not
-        // reporting “1 = not complete this cycle.”.
+        // 6.12.2.2.a. Fail if any supported monitor (except CCM and Misfire) that was “0 = complete this cycle”
+        // in part 11 is not reporting “1 = not complete this cycle.”.
         packets.forEach(this::reportNotCompleteSystems);
 
         // 6.12.2.2.b. Fail if NACK not received from OBD ECUs that did not provide a DM26 message
@@ -103,6 +106,8 @@ public class Part12Step02Controller extends StepController {
                                                                         .stream()
                                                                         .filter(s -> s.getStatus().isComplete())
                                                                         .map(MonitoredSystem::getId)
+                                                                        .filter(id -> id != COMPREHENSIVE_COMPONENT)
+                                                                        .filter(id -> id != MISFIRE)
                                                                         .filter(supportedSystems::contains)
                                                                         .collect(Collectors.toList());
     }
@@ -117,7 +122,8 @@ public class Part12Step02Controller extends StepController {
                   .stream()
                   .filter(s -> s.getStatus().isEnabled())
                   .map(MonitoredSystem::getId)
-                  .filter(id -> id != CompositeSystem.COMPREHENSIVE_COMPONENT)
+                  .filter(id -> id != COMPREHENSIVE_COMPONENT)
+                  .filter(id -> id != MISFIRE)
                   .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
Resolves #921 

Test 1.14 - Remove Step 6.1.14.2.c (and re-number subsequent steps)
Test 2.8 - Update Step 6.2.8.2.a to only compare status bits (not enabled bits)
Test 11.11 - Add Step 6.11.11.1.c to display the vehicle composite response
Test 12.2 - Update Step 6.12.2.2.a don't evaluated Misfire