### PR TITLE
Fix #930 synchronize application clock to adapter.

### DIFF
--- a/src-test/org/etools/j1939_84/bus/MultiQueueTest.java
+++ b/src-test/org/etools/j1939_84/bus/MultiQueueTest.java
@@ -48,10 +48,10 @@ public class MultiQueueTest {
         try (MultiQueue<Integer> q = new MultiQueue<>()) {
             // Smaller timeouts are inconsistent. It looks like the JIT is sometimes
             // slow.
-            Stream<Integer> stream = q.stream(30, TimeUnit.MILLISECONDS);
-            Stream<Integer> stream1 = q.stream(40, TimeUnit.MILLISECONDS);
-            Stream<Integer> stream3 = q.stream(40, TimeUnit.MILLISECONDS);
-            Stream<Integer> streamn = q.stream(50, TimeUnit.MILLISECONDS);
+            Stream<Integer> stream = q.stream(130, TimeUnit.MILLISECONDS);
+            Stream<Integer> stream1 = q.stream(140, TimeUnit.MILLISECONDS);
+            Stream<Integer> stream3 = q.stream(140, TimeUnit.MILLISECONDS);
+            Stream<Integer> streamn = q.stream(150, TimeUnit.MILLISECONDS);
             q.add(1);
             q.add(2);
             q.add(3);
@@ -81,11 +81,11 @@ public class MultiQueueTest {
     @TestDoc(description = "Verify that duplicate streams are of the same size.")
     public void testDuplicate() throws Exception {
         try (MultiQueue<Integer> queue = new MultiQueue<>()) {
-            Stream<Integer> stream1 = queue.stream(10, TimeUnit.MILLISECONDS);
+            Stream<Integer> stream1 = queue.stream(100, TimeUnit.MILLISECONDS);
             queue.add(1);
-            Stream<Integer> stream2 = queue.duplicate(stream1, 20, TimeUnit.MILLISECONDS);
+            Stream<Integer> stream2 = queue.duplicate(stream1, 200, TimeUnit.MILLISECONDS);
             queue.add(2);
-            Stream<Integer> stream3 = queue.duplicate(stream1, 30, TimeUnit.MILLISECONDS);
+            Stream<Integer> stream3 = queue.duplicate(stream1, 300, TimeUnit.MILLISECONDS);
 
             queue.add(3);
             assertEquals(3, stream1.count());
@@ -130,35 +130,27 @@ public class MultiQueueTest {
      */
     @Test
     @TestDoc(description = "Verify that timeouts interrupts streams, so that a 410 ms stream only has 410 ms of data in it.")
-    @SuppressFBWarnings(value = {
-            "WA_NOT_IN_LOOP" }, justification = "Notify actually needs to happen here, wait is needed")
     public void testTimedInterruption() throws Exception {
         // sync on q, because thread startup is unpredictably slow
         try (MultiQueue<Integer> q = new MultiQueue<>()) {
 
             // asynchronously add a packet every 10 ms.
-            new Thread(() -> {
-                synchronized (q) {
-                    // notify main thread that we are starting.
-                    q.add(-1);
-                    q.notifyAll();
-                }
-                for (int i = 0; i < 200; i++) {
+            final ExecutorService exe = Executors.newSingleThreadExecutor();
+            exe.submit(() -> {
+                q.add(-1);
+                for (int i = 0; i < 30; i++) {
                     try {
-                        Thread.sleep(10);
+                        Thread.sleep(20);
                     } catch (InterruptedException ignored) {
                     }
                     q.add(i);
                 }
-            }).start();
-
-            synchronized (q) {
-                // wait on notify
-                q.wait(1000);
-            }
-
-            Stream<Integer> s1 = q.stream(410, TimeUnit.MILLISECONDS);
-            assertEquals("40 packets were processed in 400 ms", 40, s1.count(), 10);
+            });
+            q.stream(1, TimeUnit.SECONDS).findFirst();
+            Stream<Integer> s1 = q.stream(500, TimeUnit.MILLISECONDS);
+            assertEquals("20 packets were processed in 500 ms", 20, s1.count(), 5);
+            exe.shutdown();
+            exe.awaitTermination(1, TimeUnit.MINUTES);
         }
     }
 }

--- a/src-test/org/etools/j1939_84/bus/RP1210BusTest.java
+++ b/src-test/org/etools/j1939_84/bus/RP1210BusTest.java
@@ -25,6 +25,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
@@ -69,7 +70,7 @@ public class RP1210BusTest {
                                  adapter,
                                  ADDRESS,
                                  true,
-                                 (severity, string, e) -> logger.log(severity, string, e));
+                                 (severity, string, e) -> logger.log(severity, string.get(), e));
     }
 
     @Before

--- a/src/org/etools/j1939_84/bus/Adapter.java
+++ b/src/org/etools/j1939_84/bus/Adapter.java
@@ -26,7 +26,7 @@ public class Adapter {
      */
     private final String name;
 
-    private final long timeStampWeight;
+    private final long timestampWeight;
 
     /**
      * Constructor
@@ -52,11 +52,11 @@ public class Adapter {
      * @param deviceId
      *                     the device ID
      */
-    public Adapter(String name, String dllName, short deviceId, long timeStampWeight) {
+    public Adapter(String name, String dllName, short deviceId, long timestampWeight) {
         this.name = name;
         this.dllName = dllName;
         this.deviceId = deviceId;
-        this.timeStampWeight = timeStampWeight;
+        this.timestampWeight = timestampWeight;
     }
 
     /**
@@ -86,8 +86,8 @@ public class Adapter {
         return name;
     }
 
-    public long getTimeStampWeight() {
-        return timeStampWeight;
+    public long getTimestampWeight() {
+        return timestampWeight;
     }
 
 }

--- a/src/org/etools/j1939_84/bus/RP1210.java
+++ b/src/org/etools/j1939_84/bus/RP1210.java
@@ -107,14 +107,14 @@ public class RP1210 {
                         Section vendorSection = driverIni.get("VendorInformation");
                         String vendorName = vendorSection.getOrDefault("Name", "");
 
-                        long timeStampWeight = getTimeStampWeight(vendorSection);
+                        long timestampWeight = getTimestampWeight(vendorSection);
 
                         // loop through protocols to find J1939
                         for (String protocolId : getProtocols(vendorSection)) {
                             Section protocolSection = driverIni.get("ProtocolInformation" + protocolId);
                             if (isJ1939Section(protocolSection)) {
                                 Arrays.stream(getDevices(protocolSection))
-                                      .map(devId -> createAdapter(id, driverIni, vendorName, timeStampWeight, devId))
+                                      .map(devId -> createAdapter(id, driverIni, vendorName, timestampWeight, devId))
                                       .forEach(list::add);
                             }
                         }
@@ -185,23 +185,23 @@ public class RP1210 {
         return vendorSection.getOrDefault("Protocols", "").split("\\s*,\\s*");
     }
 
-    private static long getTimeStampWeight(Section vendorSection) {
-        long timeStampWeight;
+    private static long getTimestampWeight(Section vendorSection) {
+        long timestampWeight;
         try {
-            timeStampWeight = Long.parseLong(vendorSection.getOrDefault("TimeStampWeight", "1"));
+            timestampWeight = Long.parseLong(vendorSection.getOrDefault("TimeStampWeight", "1"));
         } catch (Throwable t) {
             J1939_84.getLogger()
                     .log(Level.SEVERE,
                          "Error Parsing TimeStampWeight from ini file.  Assuming 1000 (ms resolution).",
                          t);
-            timeStampWeight = 1000;
+            timestampWeight = 1000;
         }
-        return timeStampWeight;
+        return timestampWeight;
     }
 
-    private static Adapter createAdapter(String id, Ini driver, String vendorName, long timeStampWeight, String devId) {
+    private static Adapter createAdapter(String id, Ini driver, String vendorName, long timestampWeight, String devId) {
         short deviceId = Short.parseShort(devId);
         String deviceName = driver.get("DeviceInformation" + devId).getOrDefault("DeviceDescription", "UNKNOWN");
-        return new Adapter(vendorName + " - " + deviceName, id, deviceId, timeStampWeight);
+        return new Adapter(vendorName + " - " + deviceName, id, deviceId, timestampWeight);
     }
 }

--- a/src/org/etools/j1939_84/modules/DateTimeModule.java
+++ b/src/org/etools/j1939_84/modules/DateTimeModule.java
@@ -8,7 +8,9 @@ import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
 import static java.time.temporal.ChronoField.NANO_OF_SECOND;
 import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.util.concurrent.TimeUnit;
@@ -24,6 +26,8 @@ import org.etools.j1939_84.controllers.Controller;
 public class DateTimeModule {
     private static DateTimeModule instance = new DateTimeModule();
     private DateTimeFormatter timeFormatter;
+    private long nanoOffset = System.nanoTime();
+    private Instant last;
 
     protected DateTimeModule() {
     }
@@ -90,7 +94,13 @@ public class DateTimeModule {
      * @return {@link LocalDateTime}
      */
     protected LocalDateTime now() {
-        return LocalDateTime.now();
+        Instant now = Instant.now().plusNanos(nanoOffset);
+        if (now.isBefore(last)) {
+            now = last;
+        } else {
+            last = now;
+        }
+        return LocalDateTime.ofInstant(now, ZoneId.systemDefault());
     }
 
     public void pauseFor(long milliseconds) {
@@ -100,6 +110,10 @@ public class DateTimeModule {
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public void setNanoTime(long nanoTime) {
+        nanoOffset = System.nanoTime() - nanoTime;
     }
 
 }

--- a/src/org/etools/j1939_84/modules/DateTimeModule.java
+++ b/src/org/etools/j1939_84/modules/DateTimeModule.java
@@ -13,8 +13,12 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 
+import org.etools.j1939_84.J1939_84;
 import org.etools.j1939_84.controllers.Controller;
 
 /**
@@ -27,7 +31,7 @@ public class DateTimeModule {
     private static DateTimeModule instance = new DateTimeModule();
     private DateTimeFormatter timeFormatter;
     private long nanoOffset = System.nanoTime();
-    private Instant last;
+    private Instant last = Instant.now();
 
     protected DateTimeModule() {
     }
@@ -97,6 +101,7 @@ public class DateTimeModule {
         Instant now = Instant.now().plusNanos(nanoOffset);
         if (now.isBefore(last)) {
             now = last;
+            J1939_84.getLogger().log(Level.INFO, "Reusing now: " + now);
         } else {
             last = now;
         }
@@ -112,8 +117,10 @@ public class DateTimeModule {
         }
     }
 
+    private static final long GIGA = 1000000000;
+
     public void setNanoTime(long nanoTime) {
-        nanoOffset = System.nanoTime() - nanoTime;
+        nanoOffset = Instant.now().until(Instant.ofEpochSecond(nanoTime / GIGA, nanoTime % GIGA), ChronoUnit.NANOS);
     }
 
 }

--- a/src/org/etools/j1939_84/modules/DateTimeModule.java
+++ b/src/org/etools/j1939_84/modules/DateTimeModule.java
@@ -30,7 +30,7 @@ import org.etools.j1939_84.controllers.Controller;
 public class DateTimeModule {
     private static DateTimeModule instance = new DateTimeModule();
     private DateTimeFormatter timeFormatter;
-    private long nanoOffset = System.nanoTime();
+    private long nanoOffset = 0;
     private Instant last = Instant.now();
 
     protected DateTimeModule() {


### PR DESCRIPTION
**Resolves #930 synchronize application clock to adapter.**
1. Switch timing offset from microseconds to nano seconds.
2. Add application offset, to shift application times.
3. Only update adapter offset on rollover.
4. Update tests that were failing on slow machine.
5. Move rp1210bus log message creation out of polling loop.