### PR TITLE
Fix #932 - Notify user of second device using SA F9

### DIFF
--- a/.idea/saveactions_settings.xml
+++ b/.idea/saveactions_settings.xml
@@ -16,7 +16,6 @@
         <option value="finalPrivateMethod" />
         <option value="unnecessaryFinalOnLocalVariableOrParameter" />
         <option value="explicitTypeCanBeDiamond" />
-        <option value="suppressAnnotation" />
         <option value="unnecessarySemicolon" />
       </set>
     </option>

--- a/src-test/org/etools/j1939_84/bus/RP1210BusTest.java
+++ b/src-test/org/etools/j1939_84/bus/RP1210BusTest.java
@@ -1,9 +1,11 @@
-/**
+/*
  * Copyright 2019 Equipment & Tool Institute
  */
 package org.etools.j1939_84.bus;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.etools.j1939_84.controllers.Controller.Ending.ABORTED;
+import static org.etools.j1939_84.controllers.QuestionListener.AnswerType.CANCEL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -13,6 +15,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -29,6 +32,10 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 
+import org.etools.j1939_84.events.CompleteEvent;
+import org.etools.j1939_84.events.EventBus;
+import org.etools.j1939_84.events.ResultEvent;
+import org.etools.j1939_84.events.UrgentEvent;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -44,6 +51,7 @@ import org.mockito.junit.MockitoJUnitRunner;
  * @author Matt Gumbel (matt@soliddesign.net)
  *
  */
+@SuppressWarnings("unchecked")
 @RunWith(MockitoJUnitRunner.class)
 public class RP1210BusTest {
 
@@ -61,6 +69,8 @@ public class RP1210BusTest {
     private MultiQueue<Packet> queue;
     @Mock
     private RP1210Library rp1210Library;
+    @Mock
+    private EventBus eventBus;
 
     private void createInstance() throws BusException {
         instance = new RP1210Bus(rp1210Library,
@@ -69,12 +79,18 @@ public class RP1210BusTest {
                                  adapter,
                                  ADDRESS,
                                  true,
-                                 (severity, string, e) -> logger.log(severity, string, e));
+                                 (severity, string, e) -> logger.log(severity, string, e),
+                                 eventBus);
     }
 
     @Before
     public void setUp() throws Exception {
         adapter = new Adapter("Testing Adapter", "TST_ADPTR", (short) 42);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        verifyNoMoreInteractions(rp1210Library, exec, queue, logger, eventBus);
     }
 
     private void startInstance() throws Exception {
@@ -112,11 +128,6 @@ public class RP1210BusTest {
                                                  aryEq(new byte[] {}),
                                                  eq((short) 0));
         verify(exec).scheduleAtFixedRate(any(Runnable.class), eq(1L), eq(1L), eq(TimeUnit.MILLISECONDS));
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        verifyNoMoreInteractions(rp1210Library, exec, queue, logger);
     }
 
     @Test
@@ -159,7 +170,7 @@ public class RP1210BusTest {
     }
 
     @Test
-    public void testConstructorConnectFails() throws Exception {
+    public void testConstructorConnectFails() {
         when(rp1210Library.RP1210_ClientConnect(0, (short) 42, "J1939:Baud=Auto", 0, 0, (short) 1))
                                                                                                    .thenReturn((short) 134);
         when(rp1210Library.RP1210_GetErrorMsg(eq((short) 134), any())).thenAnswer(arg0 -> {
@@ -284,7 +295,7 @@ public class RP1210BusTest {
     }
 
     @Test
-    public void testConstructorStopFails() throws Exception {
+    public void testConstructorStopFails() {
         when(rp1210Library.RP1210_ClientConnect(0, (short) 42, "J1939:Baud=Auto", 0, 0, (short) 1))
                                                                                                    .thenReturn((short) 1);
 
@@ -509,17 +520,28 @@ public class RP1210BusTest {
                 (byte) 0x06, (byte) ADDRESS, (byte) 0x34, (byte) 0x77, (byte) 0x88, (byte) 0x99, (byte) 0xAA,
                 (byte) 0xBB,
                 (byte) 0xCC, (byte) 0xDD, (byte) 0xEE };
-        when(rp1210Library.RP1210_ReadMessage(eq((short) 1), any(byte[].class), eq((short) 2048), eq((short) 0)))
-                                                                                                                 .thenAnswer(arg0 -> {
-                                                                                                                     byte[] data = arg0.getArgument(1);
-                                                                                                                     System.arraycopy(encodedPacket,
-                                                                                                                                      0,
-                                                                                                                                      data,
-                                                                                                                                      0,
-                                                                                                                                      encodedPacket.length);
-                                                                                                                     return (short) encodedPacket.length;
-                                                                                                                 })
-                                                                                                                 .thenReturn((short) 0);
+        when(rp1210Library.RP1210_ReadMessage(eq((short) 1),
+                                              any(byte[].class),
+                                              eq((short) 2048),
+                                              eq((short) 0)))
+                                                             .thenAnswer(arg0 -> {
+                                                                 byte[] data = arg0.getArgument(1);
+                                                                 System.arraycopy(encodedPacket,
+                                                                                  0,
+                                                                                  data,
+                                                                                  0,
+                                                                                  encodedPacket.length);
+                                                                 return (short) encodedPacket.length;
+                                                             })
+                                                             .thenReturn((short) 0);
+
+        String uiMsg = "Unexpected Service Tool Message from SA 0xF9 observed. Test results uncertain. False failures are possible";
+
+        doAnswer(invocationOnMock -> {
+            UrgentEvent event = invocationOnMock.getArgument(0);
+            event.getQuestionListener().answered(CANCEL);
+            return null;
+        }).when(eventBus).publish(any(UrgentEvent.class));
 
         startInstance();
         Runnable runnable = runnableCaptor.getValue();
@@ -539,6 +561,10 @@ public class RP1210BusTest {
         verify(logger).log(Level.WARNING,
                            "Another ECU is using this address: 181234A5 [8] 77 88 99 AA BB CC DD EE",
                            (Throwable) null);
+
+        verify(eventBus).publish(new ResultEvent("INVALID: " + uiMsg));
+        verify(eventBus).publish(any(UrgentEvent.class));
+        verify(eventBus).publish(new CompleteEvent(ABORTED));
     }
 
     @Test

--- a/src-test/org/etools/j1939_84/bus/RP1210BusTest.java
+++ b/src-test/org/etools/j1939_84/bus/RP1210BusTest.java
@@ -6,6 +6,7 @@ package org.etools.j1939_84.bus;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.etools.j1939_84.controllers.Controller.Ending.ABORTED;
 import static org.etools.j1939_84.controllers.QuestionListener.AnswerType.CANCEL;
+import static org.etools.j1939_84.controllers.ResultsListener.MessageType.ERROR;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -535,8 +536,6 @@ public class RP1210BusTest {
                                                              })
                                                              .thenReturn((short) 0);
 
-        String uiMsg = "Unexpected Service Tool Message from SA 0xF9 observed. Test results uncertain. False failures are possible";
-
         doAnswer(invocationOnMock -> {
             UrgentEvent event = invocationOnMock.getArgument(0);
             event.getQuestionListener().answered(CANCEL);
@@ -562,8 +561,11 @@ public class RP1210BusTest {
                            "Another ECU is using this address: 181234A5 [8] 77 88 99 AA BB CC DD EE",
                            (Throwable) null);
 
+        String uiMsg = "Unexpected Service Tool Message from SA 0xF9 observed. Test results uncertain. False failures are possible";
+
         verify(eventBus).publish(new ResultEvent("INVALID: " + uiMsg));
-        verify(eventBus).publish(any(UrgentEvent.class));
+        verify(eventBus).publish(new UrgentEvent(uiMsg, "Second device using SA 0xF9", ERROR, answerType -> {
+        }));
         verify(eventBus).publish(new CompleteEvent(ABORTED));
     }
 

--- a/src/org/etools/j1939_84/bus/RP1210Bus.java
+++ b/src/org/etools/j1939_84/bus/RP1210Bus.java
@@ -1,8 +1,9 @@
-/**
+/*
  * Copyright 2019 Equipment & Tool Institute
  */
 package org.etools.j1939_84.bus;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.etools.j1939_84.bus.RP1210Library.BLOCKING_NONE;
 import static org.etools.j1939_84.bus.RP1210Library.CLAIM_BLOCK_UNTIL_DONE;
 import static org.etools.j1939_84.bus.RP1210Library.CMD_ECHO_TRANSMITTED_MESSAGES;
@@ -11,8 +12,10 @@ import static org.etools.j1939_84.bus.RP1210Library.CMD_PROTECT_J1939_ADDRESS;
 import static org.etools.j1939_84.bus.RP1210Library.CMD_SET_ALL_FILTERS_STATES_TO_PASS;
 import static org.etools.j1939_84.bus.RP1210Library.ECHO_ON;
 import static org.etools.j1939_84.bus.RP1210Library.NOTIFICATION_NONE;
+import static org.etools.j1939_84.controllers.Controller.Ending.ABORTED;
+import static org.etools.j1939_84.controllers.QuestionListener.AnswerType.CANCEL;
+import static org.etools.j1939_84.controllers.ResultsListener.MessageType.ERROR;
 
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -21,11 +24,16 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 
 import org.etools.j1939_84.J1939_84;
+import org.etools.j1939_84.events.CompleteEvent;
+import org.etools.j1939_84.events.EventBus;
+import org.etools.j1939_84.events.ResultEvent;
+import org.etools.j1939_84.events.UrgentEvent;
 
 /**
  * The RP1210 implementation of a {@link Bus}
@@ -55,12 +63,6 @@ public class RP1210Bus implements Bus {
      */
     private final ScheduledExecutorService exec;
 
-    interface BusLogger {
-
-        void log(Level severe, String string, BusException e);
-
-    }
-
     /**
      * The {@link Logger} for errors
      */
@@ -76,10 +78,12 @@ public class RP1210Bus implements Bus {
      */
     final private long timeStampWeight;
 
+    private final EventBus eventBus;
+
     /**
      * The Queue of {@link Packet}s
      */
-    private MultiQueue<Packet> queue = new MultiQueue<>();
+    private MultiQueue<Packet> queue;
 
     /**
      * An adjustment offset for the adapter time to system time. Adapters don't have batteries, so their clocks are
@@ -87,24 +91,8 @@ public class RP1210Bus implements Bus {
      */
     private long timeStampStartMicroseconds;
 
-    /**
-     * Constructor
-     *
-     * @param  adapter
-     *                          the {@link Adapter} thats connected to the vehicle
-     * @param  address
-     *                          the address of this branch on the bus
-     * @throws BusException
-     *                          if there is a problem connecting to the adapter
-     */
-    public RP1210Bus(Adapter adapter, int address, boolean appPacketize) throws BusException {
-        this(RP1210Library.load(adapter),
-             Executors.newSingleThreadScheduledExecutor(),
-             new MultiQueue<>(),
-             adapter,
-             address,
-             appPacketize,
-             createBusAsyncLogger(J1939_84.getLogger()));
+    interface BusLogger {
+        void log(Level severe, String string, BusException e);
     }
 
     private static BusLogger createBusAsyncLogger(Logger logger) {
@@ -112,30 +100,19 @@ public class RP1210Bus implements Bus {
         return (severity, string, e) -> exe.execute(() -> logger.log(severity, string, e));
     }
 
+    public RP1210Bus(Adapter adapter, int address, boolean appPacketize) throws BusException {
+        this(RP1210Library.load(adapter),
+             Executors.newSingleThreadScheduledExecutor(),
+             new MultiQueue<>(),
+             adapter,
+             address,
+             appPacketize,
+             createBusAsyncLogger(J1939_84.getLogger()),
+             EventBus.getInstance());
+    }
+
     /**
      * Constructor exposed for testing
-     *
-     * @param  rp1210Library
-     *                           the {@link RP1210Library} that connects to the adapter
-     *
-     * @param  exec
-     *                           the {@link ScheduledExecutorService} that will execute tasks
-     *
-     * @param  adapter
-     *                           the {@link Adapter} thats connected to the vehicle
-     *
-     * @param  address
-     *                           the source address of this branch on the bus
-     *
-     * @param  logger
-     *                           the {@link Logger} for logging errors
-     *
-     * @param  queue
-     *                           the {@link Packet} for logging errors
-     *
-     * @throws BusException
-     *                           if there is a problem connecting to the adapter
-     *
      */
     public RP1210Bus(RP1210Library rp1210Library,
                      ScheduledExecutorService exec,
@@ -143,7 +120,8 @@ public class RP1210Bus implements Bus {
                      Adapter adapter,
                      int address,
                      boolean appPacketize,
-                     BusLogger logger) throws BusException {
+                     BusLogger logger,
+                     EventBus eventBus) throws BusException {
         this.rp1210Library = rp1210Library;
         this.exec = exec;
         this.queue = queue;
@@ -151,15 +129,15 @@ public class RP1210Bus implements Bus {
         this.logger = logger;
         timeStampWeight = adapter.getTimeStampWeight();
         timeStampStartMicroseconds = 0;
+        this.eventBus = eventBus;
 
-        clientId = rp1210Library
-                                .RP1210_ClientConnect(0,
+        clientId = rp1210Library.RP1210_ClientConnect(0,
                                                       adapter.getDeviceId(),
                                                       "J1939:Baud=Auto",
                                                       0,
                                                       0,
                                                       (short) (appPacketize ? 1 : 0));
-        verify(clientId);
+        checkReturnCode(clientId);
         try {
             sendCommand(CMD_PROTECT_J1939_ADDRESS,
                         new byte[] { (byte) address, 0, 0, (byte) 0xE0, (byte) 0xFF, 0,
@@ -167,7 +145,7 @@ public class RP1210Bus implements Bus {
             sendCommand(CMD_ECHO_TRANSMITTED_MESSAGES, ECHO_ON);
             sendCommand(CMD_SET_ALL_FILTERS_STATES_TO_PASS);
 
-            this.exec.scheduleAtFixedRate(() -> poll(), 1, 1, TimeUnit.MILLISECONDS);
+            this.exec.scheduleAtFixedRate(this::poll, 1, 1, TimeUnit.MILLISECONDS);
         } catch (Throwable e) {
             stop();
             throw new BusException("Failed to configure adapter.", e);
@@ -194,7 +172,7 @@ public class RP1210Bus implements Bus {
     public int getConnectionSpeed() throws BusException {
         byte[] bytes = new byte[17];
         sendCommand(CMD_GET_PROTOCOL_CONNECTION_SPEED, bytes);
-        String result = new String(bytes, StandardCharsets.UTF_8).trim();
+        String result = new String(bytes, UTF_8).trim();
         return Integer.parseInt(result);
     }
 
@@ -223,7 +201,7 @@ public class RP1210Bus implements Bus {
                                                                            NOTIFICATION_NONE,
                                                                            BLOCKING_NONE))
                             .get();
-            verify(rtn);
+            checkReturnCode(rtn);
             int id = tx.getId(0xFFFF);
             int source = tx.getSource();
             return stream
@@ -259,7 +237,7 @@ public class RP1210Bus implements Bus {
         }
 
         Instant time = adapterTimestampToInstant(timestamp);
-        final long diff = Math.abs(time.toEpochMilli() - Instant.now().toEpochMilli());
+        long diff = Math.abs(time.toEpochMilli() - Instant.now().toEpochMilli());
         if (diff > 1000) {
             timeStampStartMicroseconds = 1000 * System.currentTimeMillis() - timestamp * timeStampWeight;
             getLogger().log(Level.INFO, String.format("adapter time offset: %,d µs", timeStampStartMicroseconds), null);
@@ -318,25 +296,18 @@ public class RP1210Bus implements Bus {
                 short rtn = rp1210Library.RP1210_ReadMessage(clientId, data, (short) data.length, BLOCKING_NONE);
                 if (rtn > 0) {
                     Packet packet = decode(data, rtn);
-                    if (packet.getSource() == getAddress() && !packet.isTransmitted()) {
-                        getLogger().log(Level.WARNING, "Another ECU is using this address: " + packet, null);
-                    }
-                    getLogger().log(Level.FINE, packet.toTimeString(), null);
+                    logPacket(packet);
                     queue.add(packet);
                 } else if (rtn == -RP1210Library.ERR_RX_QUEUE_FULL) {
                     // RX queue full, remedy is to reread.
-                    byte[] buffer = new byte[256];
-                    rp1210Library.RP1210_GetErrorMsg((short) Math.abs(rtn), buffer);
-                    getLogger().log(Level.SEVERE,
-                                    "Error (" + rtn + "): " + new String(buffer, StandardCharsets.UTF_8).trim(),
-                                    null);
+                    logger.log(Level.SEVERE, getErrorMessage(rtn), null);
                 } else {
-                    verify(rtn);
+                    checkReturnCode(rtn);
                     break;
                 }
             }
         } catch (BusException e) {
-            getLogger().log(Level.SEVERE, "Failed to read RP1210", e);
+            logger.log(Level.SEVERE, "Failed to read RP1210", e);
         }
     }
 
@@ -352,7 +323,7 @@ public class RP1210Bus implements Bus {
      */
     private void sendCommand(short command, byte... data) throws BusException {
         short rtn = rp1210Library.RP1210_SendCommand(command, clientId, data, (short) data.length);
-        verify(rtn);
+        checkReturnCode(rtn);
     }
 
     /**
@@ -382,12 +353,41 @@ public class RP1210Bus implements Bus {
      * @throws BusException
      *                          if the return code is an error
      */
-    private void verify(short rtnCode) throws BusException {
+    private void checkReturnCode(short rtnCode) throws BusException {
         if (rtnCode > 127 || rtnCode < 0) {
-            rtnCode = (short) Math.abs(rtnCode);
-            byte[] buffer = new byte[256];
-            rp1210Library.RP1210_GetErrorMsg(rtnCode, buffer);
-            throw new BusException("Error (" + rtnCode + "): " + new String(buffer, StandardCharsets.UTF_8).trim());
+            String errorMessage = getErrorMessage(rtnCode);
+            throw new BusException(errorMessage);
         }
+    }
+
+    private final AtomicBoolean reportedImposter = new AtomicBoolean(false);
+
+    private void logPacket(Packet packet) {
+        logger.log(Level.FINE, packet.toTimeString(), null);
+
+        if (packet.getSource() == getAddress() && !packet.isTransmitted()) {
+            String msg = "Another ECU is using this address: " + packet;
+            logger.log(Level.WARNING, msg, null);
+
+            if (reportedImposter.compareAndSet(false, true)) {
+                String uiMsg = "Unexpected Service Tool Message from SA 0xF9 observed. Test results uncertain. False failures are possible";
+                eventBus.publish(new ResultEvent("INVALID: " + uiMsg));
+                eventBus.publish(new UrgentEvent(uiMsg,
+                                                 "Second device using SA 0xF9",
+                                                 ERROR,
+                                                 answerType -> {
+                                                     if (answerType == CANCEL) {
+                                                         eventBus.publish(new CompleteEvent(ABORTED));
+                                                     }
+                                                 }));
+            }
+        }
+    }
+
+    private String getErrorMessage(short rtnCode) {
+        rtnCode = (short) Math.abs(rtnCode);
+        byte[] buffer = new byte[256];
+        rp1210Library.RP1210_GetErrorMsg(rtnCode, buffer);
+        return "Error (" + rtnCode + "): " + new String(buffer, UTF_8).trim();
     }
 }

--- a/src/org/etools/j1939_84/bus/RP1210Bus.java
+++ b/src/org/etools/j1939_84/bus/RP1210Bus.java
@@ -24,7 +24,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
@@ -360,7 +359,7 @@ public class RP1210Bus implements Bus {
         }
     }
 
-    private final AtomicBoolean reportedImposter = new AtomicBoolean(false);
+    private boolean reportedImposter = false;
 
     private void logPacket(Packet packet) {
         logger.log(Level.FINE, packet.toTimeString(), null);
@@ -369,7 +368,7 @@ public class RP1210Bus implements Bus {
             String msg = "Another ECU is using this address: " + packet;
             logger.log(Level.WARNING, msg, null);
 
-            if (reportedImposter.compareAndSet(false, true)) {
+            if (!reportedImposter) {
                 String uiMsg = "Unexpected Service Tool Message from SA 0xF9 observed. Test results uncertain. False failures are possible";
                 eventBus.publish(new ResultEvent("INVALID: " + uiMsg));
                 eventBus.publish(new UrgentEvent(uiMsg,
@@ -380,6 +379,7 @@ public class RP1210Bus implements Bus {
                                                          eventBus.publish(new CompleteEvent(ABORTED));
                                                      }
                                                  }));
+                reportedImposter = true;
             }
         }
     }

--- a/src/org/etools/j1939_84/events/CompleteEvent.java
+++ b/src/org/etools/j1939_84/events/CompleteEvent.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021. Equipment & Tool Institute
+ */
+
+package org.etools.j1939_84.events;
+
+import java.util.Objects;
+
+import org.etools.j1939_84.controllers.Controller.Ending;
+
+public class CompleteEvent implements Event {
+
+    private final Ending ending;
+
+    public CompleteEvent(Ending ending) {
+        this.ending = ending;
+    }
+
+    public Ending getEnding() {
+        return ending;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CompleteEvent that = (CompleteEvent) o;
+        return getEnding() == that.getEnding();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getEnding());
+    }
+}

--- a/src/org/etools/j1939_84/events/Event.java
+++ b/src/org/etools/j1939_84/events/Event.java
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2021. Equipment & Tool Institute
+ */
+
+package org.etools.j1939_84.events;
+
+public interface Event {
+}

--- a/src/org/etools/j1939_84/events/EventBus.java
+++ b/src/org/etools/j1939_84/events/EventBus.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021. Equipment & Tool Institute
+ */
+
+package org.etools.j1939_84.events;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class EventBus {
+
+    private static final EventBus instance = new EventBus();
+
+    public static EventBus getInstance() {
+        return instance;
+    }
+
+    private final List<EventListener> listeners = new ArrayList<>();
+
+    public EventBus() {
+    }
+
+    public void publish(Event event) {
+        listeners.forEach(l -> l.onEvent(event));
+    }
+
+    public void registerListener(EventListener listener) {
+        listeners.add(listener);
+    }
+
+    public void unregisterListener(EventListener listener) {
+        listeners.remove(listener);
+    }
+
+}

--- a/src/org/etools/j1939_84/events/EventListener.java
+++ b/src/org/etools/j1939_84/events/EventListener.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2021. Equipment & Tool Institute
+ */
+
+package org.etools.j1939_84.events;
+
+public interface EventListener {
+
+    void onEvent(Event event);
+}

--- a/src/org/etools/j1939_84/events/MessageEvent.java
+++ b/src/org/etools/j1939_84/events/MessageEvent.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021. Equipment & Tool Institute
+ */
+
+package org.etools.j1939_84.events;
+
+import java.util.Objects;
+
+import org.etools.j1939_84.controllers.ResultsListener.MessageType;
+
+public class MessageEvent implements Event {
+
+    private final String message;
+    private final String title;
+    private final MessageType messageType;
+
+    public MessageEvent(String message, String title, MessageType messageType) {
+        this.message = message;
+        this.title = title;
+        this.messageType = messageType;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public MessageType getMessageType() {
+        return messageType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MessageEvent that = (MessageEvent) o;
+        return Objects.equals(getMessage(), that.getMessage())
+                && Objects.equals(getTitle(), that.getTitle())
+                && getMessageType() == that.getMessageType();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getMessage(), getTitle(), getMessageType());
+    }
+}

--- a/src/org/etools/j1939_84/events/OutcomeEvent.java
+++ b/src/org/etools/j1939_84/events/OutcomeEvent.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2021. Equipment & Tool Institute
+ */
+
+package org.etools.j1939_84.events;
+
+import java.util.Objects;
+
+import org.etools.j1939_84.model.Outcome;
+
+public class OutcomeEvent implements Event {
+
+    private final int partNumber;
+    private final int stepNumber;
+    private final Outcome outcome;
+    private final String message;
+
+    public OutcomeEvent(int partNumber, int stepNumber, Outcome outcome, String message) {
+        this.partNumber = partNumber;
+        this.stepNumber = stepNumber;
+        this.outcome = outcome;
+        this.message = message;
+    }
+
+    public int getPartNumber() {
+        return partNumber;
+    }
+
+    public int getStepNumber() {
+        return stepNumber;
+    }
+
+    public Outcome getOutcome() {
+        return outcome;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OutcomeEvent that = (OutcomeEvent) o;
+        return getPartNumber() == that.getPartNumber()
+                && getStepNumber() == that.getStepNumber()
+                && getOutcome() == that.getOutcome()
+                && Objects.equals(getMessage(), that.getMessage());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getPartNumber(), getStepNumber(), getOutcome(), getMessage());
+    }
+}

--- a/src/org/etools/j1939_84/events/ProgressEvent.java
+++ b/src/org/etools/j1939_84/events/ProgressEvent.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2021. Equipment & Tool Institute
+ */
+
+package org.etools.j1939_84.events;
+
+import java.util.Objects;
+
+public class ProgressEvent implements Event {
+
+    private final int currentStep;
+    private final int totalSteps;
+    private final String message;
+
+    public ProgressEvent(int currentStep, int totalSteps, String message) {
+        this.currentStep = currentStep;
+        this.totalSteps = totalSteps;
+        this.message = message;
+    }
+
+    public ProgressEvent(String message) {
+        currentStep = -1;
+        totalSteps = -1;
+        this.message = message;
+    }
+
+    public int getCurrentStep() {
+        return currentStep;
+    }
+
+    public int getTotalSteps() {
+        return totalSteps;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ProgressEvent that = (ProgressEvent) o;
+        return getCurrentStep() == that.getCurrentStep()
+                && getTotalSteps() == that.getTotalSteps()
+                && Objects.equals(getMessage(), that.getMessage());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getCurrentStep(), getTotalSteps(), getMessage());
+    }
+}

--- a/src/org/etools/j1939_84/events/RequestVehInfoEvent.java
+++ b/src/org/etools/j1939_84/events/RequestVehInfoEvent.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021. Equipment & Tool Institute
+ */
+
+package org.etools.j1939_84.events;
+
+import java.util.Objects;
+
+import org.etools.j1939_84.model.VehicleInformationListener;
+
+public class RequestVehInfoEvent implements Event {
+
+    private final VehicleInformationListener listener;
+
+    public RequestVehInfoEvent(VehicleInformationListener listener) {
+        this.listener = listener;
+    }
+
+    public VehicleInformationListener getListener() {
+        return listener;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RequestVehInfoEvent that = (RequestVehInfoEvent) o;
+        return Objects.equals(getListener(), that.getListener());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getListener());
+    }
+}

--- a/src/org/etools/j1939_84/events/ResultEvent.java
+++ b/src/org/etools/j1939_84/events/ResultEvent.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021. Equipment & Tool Institute
+ */
+
+package org.etools.j1939_84.events;
+
+import static org.etools.j1939_84.J1939_84.NL;
+
+import java.util.List;
+import java.util.Objects;
+
+public class ResultEvent implements Event {
+
+    private final List<String> results;
+
+    public ResultEvent(List<String> results) {
+        this.results = results;
+    }
+
+    public ResultEvent(String result) {
+        results = List.of(result);
+    }
+
+    public String getResult() {
+        if (results.size() == 1) {
+            return results.get(0);
+        } else {
+            StringBuilder sb = new StringBuilder();
+            results.forEach(r -> sb.append(r).append(NL));
+            return sb.toString();
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ResultEvent that = (ResultEvent) o;
+        return Objects.equals(results, that.results);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(results);
+    }
+}

--- a/src/org/etools/j1939_84/events/StartEvent.java
+++ b/src/org/etools/j1939_84/events/StartEvent.java
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2021. Equipment & Tool Institute
+ */
+
+package org.etools.j1939_84.events;
+
+public class StartEvent implements Event {
+}

--- a/src/org/etools/j1939_84/events/UrgentEvent.java
+++ b/src/org/etools/j1939_84/events/UrgentEvent.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2021. Equipment & Tool Institute
+ */
+
+package org.etools.j1939_84.events;
+
+import java.util.Objects;
+
+import org.etools.j1939_84.controllers.QuestionListener;
+import org.etools.j1939_84.controllers.ResultsListener.MessageType;
+
+public class UrgentEvent implements Event {
+
+    private final String message;
+    private final String title;
+    private final MessageType messageType;
+    private final QuestionListener questionListener;
+
+    public UrgentEvent(String message, String title, MessageType messageType, QuestionListener questionListener) {
+        this.message = message;
+        this.title = title;
+        this.messageType = messageType;
+        this.questionListener = questionListener;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public MessageType getMessageType() {
+        return messageType;
+    }
+
+    public QuestionListener getQuestionListener() {
+        return questionListener;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UrgentEvent that = (UrgentEvent) o;
+        return Objects.equals(getMessage(), that.getMessage())
+                && Objects.equals(getTitle(), that.getTitle())
+                && getMessageType() == that.getMessageType();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getMessage(), getTitle(), getMessageType());
+    }
+}

--- a/src/org/etools/j1939_84/events/VehicleInfoEvent.java
+++ b/src/org/etools/j1939_84/events/VehicleInfoEvent.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021. Equipment & Tool Institute
+ */
+
+package org.etools.j1939_84.events;
+
+import java.util.Objects;
+
+import org.etools.j1939_84.model.VehicleInformation;
+
+public class VehicleInfoEvent implements Event {
+
+    private final VehicleInformation vehicleInformation;
+
+    public VehicleInfoEvent(VehicleInformation vehicleInformation) {
+        this.vehicleInformation = vehicleInformation;
+    }
+
+    public VehicleInformation getVehicleInformation() {
+        return vehicleInformation;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        VehicleInfoEvent that = (VehicleInfoEvent) o;
+        return Objects.equals(getVehicleInformation(), that.getVehicleInformation());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getVehicleInformation());
+    }
+}


### PR DESCRIPTION
Resolves  #932 

@battjt, I need you to test this with an adapter.

I created an `EventBus` which is intended to replace the `ResultsListener`.  I started to replace the `ResultsListener` everywhere and the change grew too large and too risky to implement now. 

So as a stop-gap, the `Controller` will listen for the `Event`s on the `EventBus` and send them to the rest of the app via the `CompositeResultsListener`. 

In V3.1 we can replace the `ResultsListener` which will clean up a lot of   ##code.

