### PR TITLE
merge mistakes.

### DIFF
--- a/src/org/etools/j1939_84/bus/Bus.java
+++ b/src/org/etools/j1939_84/bus/Bus.java
@@ -94,4 +94,9 @@ public interface Bus extends AutoCloseable {
      */
     Packet send(Packet packet) throws BusException;
 
+    /**
+     * 
+     * @return if another module is detected on the CAN bus using this address.
+     */
+    boolean imposterDetected();
 }

--- a/src/org/etools/j1939_84/bus/EchoBus.java
+++ b/src/org/etools/j1939_84/bus/EchoBus.java
@@ -80,4 +80,9 @@ public class EchoBus implements Bus {
         queue.add(p);
         return p;
     }
+
+    @Override
+    public boolean imposterDetected() {
+        return false;
+    }
 }

--- a/src/org/etools/j1939_84/bus/Packet.java
+++ b/src/org/etools/j1939_84/bus/Packet.java
@@ -330,7 +330,10 @@ public class Packet {
             }
         }
         if (data.length == 0) {
-            throw new PacketException("Failed Packet");
+            throw new PacketException(String.format("Failed Packet: %s %06X%02X [?] ...",
+                                                    DateTimeModule.getInstance().getTimeFormatter().format(timestamp),
+                                                    priority << 18 | id,
+                                                    source));
         }
         return data;
     }

--- a/src/org/etools/j1939_84/bus/RP1210Bus.java
+++ b/src/org/etools/j1939_84/bus/RP1210Bus.java
@@ -334,10 +334,6 @@ public class RP1210Bus implements Bus {
         }
     }
 
-    public boolean isImposterFound() {
-        return imposterDetected;
-    }
-
     /**
      * Helper method to send a command to the library
      *

--- a/src/org/etools/j1939_84/bus/j1939/J1939TP.java
+++ b/src/org/etools/j1939_84/bus/j1939/J1939TP.java
@@ -505,4 +505,9 @@ public class J1939TP implements Bus {
             super("EOM not received.");
         }
     }
+
+    @Override
+    public boolean imposterDetected() {
+        return bus.imposterDetected();
+    }
 }


### PR DESCRIPTION
1. Restore lost timestamp scaling factor.
2. Fix spelling of timestamp.
3. Restore logging of packets using F9, not sent from tool.