### PR TITLE
Fix #935 only use rp1210 from adapter thread

### DIFF
--- a/src-test/org/etools/j1939_84/bus/MultiQueueTest.java
+++ b/src-test/org/etools/j1939_84/bus/MultiQueueTest.java
@@ -48,10 +48,10 @@ public class MultiQueueTest {
         try (MultiQueue<Integer> q = new MultiQueue<>()) {
             // Smaller timeouts are inconsistent. It looks like the JIT is sometimes
             // slow.
-            Stream<Integer> stream = q.stream(130, TimeUnit.MILLISECONDS);
-            Stream<Integer> stream1 = q.stream(140, TimeUnit.MILLISECONDS);
-            Stream<Integer> stream3 = q.stream(140, TimeUnit.MILLISECONDS);
-            Stream<Integer> streamn = q.stream(150, TimeUnit.MILLISECONDS);
+            Stream<Integer> stream = q.stream(100, TimeUnit.MILLISECONDS);
+            Stream<Integer> stream1 = q.stream(200, TimeUnit.MILLISECONDS);
+            Stream<Integer> stream3 = q.stream(200, TimeUnit.MILLISECONDS);
+            Stream<Integer> streamn = q.stream(300, TimeUnit.MILLISECONDS);
             q.add(1);
             q.add(2);
             q.add(3);

--- a/src/org/etools/j1939_84/bus/RP1210Bus.java
+++ b/src/org/etools/j1939_84/bus/RP1210Bus.java
@@ -189,20 +189,19 @@ public class RP1210Bus implements Bus {
 
     @Override
     public int getConnectionSpeed() throws BusException {
-        byte[] bytes = new byte[128];
-        Arrays.fill(bytes, (byte) 0);
         try {
-            exec.submit(() -> {
+            return exec.submit(() -> {
+                byte[] bytes = new byte[128];
                 sendCommand(CMD_GET_PROTOCOL_CONNECTION_SPEED, bytes);
-                return null;
+                return Integer.parseInt(new String(bytes, UTF_8).trim());
             }).get();
         } catch (InterruptedException e) {
             logger.log(Level.WARNING, () -> "Unable to read bus speed.", e);
+            throw new BusException("Unable to read bus speed.", e);
         } catch (ExecutionException e) {
             logger.log(Level.WARNING, () -> "Unable to read bus speed.", e.getCause());
+            throw new BusException("Unable to read bus speed.", e.getCause());
         }
-        String result = new String(bytes, UTF_8).trim();
-        return Integer.parseInt(result);
     }
 
     @Override


### PR DESCRIPTION
Move getConnectionSpeed string decoding to thread for more stability.
Fix Rp1210BusTest to account for send being in executor.
Improve fragile time based test.
