### PR TITLE
Fix #959 - Error: arraycopy: length -1 is negative

### DIFF
--- a/src-test/org/etools/j1939_84/bus/j1939/packets/SlotTest.java
+++ b/src-test/org/etools/j1939_84/bus/j1939/packets/SlotTest.java
@@ -18,6 +18,16 @@ import org.junit.Test;
  * @author Matt Gumbel (matt@soliddesign.net)
  */
 public class SlotTest {
+
+    @Test
+    public void testNoData() {
+        Slot slot = J1939DaRepository.findSlot(205, 0);
+        byte[] data = {};
+        assertEquals("Not Available", slot.asString(data));
+        assertTrue(slot.isNotAvailable(data));
+        assertFalse(slot.isError(data));
+    }
+
     @Test
     public void test10BitsAsPercent() {
         Slot slot = J1939DaRepository.findSlot(205, 0);

--- a/src-test/org/etools/j1939_84/bus/j1939/packets/model/SpnDataParserTest.java
+++ b/src-test/org/etools/j1939_84/bus/j1939/packets/model/SpnDataParserTest.java
@@ -156,4 +156,14 @@ public class SpnDataParserTest {
         assertEquals((byte) 0x88, resultData[7]);
     }
 
+    @Test
+    public void testTooFewBytes() {
+        byte[] data = { 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, (byte) 0x88 };
+        SpnDefinition definition = new SpnDefinition(0, null, 10, 1, 0);
+
+        byte[] resultData = instance.parse(data, definition, 8);
+
+        assertEquals(0, resultData.length);
+    }
+
 }

--- a/src/org/etools/j1939_84/bus/j1939/packets/Slot.java
+++ b/src/org/etools/j1939_84/bus/j1939/packets/Slot.java
@@ -41,7 +41,7 @@ public class Slot {
      */
     public String asString(byte[] data) {
         if (data.length == 0) {
-            return "";
+            return "Not Available";
         }
 
         if (isAscii()) {
@@ -199,8 +199,12 @@ public class Slot {
     }
 
     public boolean isNotAvailable(byte[] data) {
-        if (length == 1 || isAscii() || data.length == 0) {
+        if (length == 1 || isAscii()) {
             return false;
+        }
+
+        if (data.length == 0) {
+            return true;
         }
 
         long value = toValue(data);

--- a/src/org/etools/j1939_84/bus/j1939/packets/model/SpnDataParser.java
+++ b/src/org/etools/j1939_84/bus/j1939/packets/model/SpnDataParser.java
@@ -25,6 +25,9 @@ public class SpnDataParser {
         }
 
         int endByte = startByte + byteLength;
+        if (endByte > data.length) {
+            return new byte[0];
+        }
 
         byte[] subData = Arrays.copyOfRange(data, startByte, endByte);
         if (startBit != 1) {


### PR DESCRIPTION
Resolves #959 

The engine sent a message that was too short.  The message should have been 40 bytes long.  The tool only received 34 bytes.  When parsing the SPs, the exception was thrown.