### PR TITLE
Fix #960 - Failure Count Incorrect observation

### DIFF
--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step12ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step12ControllerTest.java
@@ -433,7 +433,7 @@ public class Part01Step12ControllerTest extends AbstractControllerTest {
         verify(mockListener).addOutcome(PART_NUMBER,
                                         STEP_NUMBER,
                                         FAIL,
-                                        "6.1.12.2.a (A7.1.c) - #1 SLOT identifier for SPN 157 from Engine #1 (0) is invalid");
+                                        "6.1.12.2.a (A7.1.c) - #1 SLOT identifier for SPN 157 FMI 0 from Engine #1 (0) is invalid");
 
         verify(diagnosticMessageModule).requestTestResults(any(), eq(0x00), eq(247), eq(supportedSPN.getSpn()), eq(31));
 

--- a/src/org/etools/j1939_84/controllers/part01/Part01Step12Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step12Controller.java
@@ -183,8 +183,8 @@ public class Part01Step12Controller extends StepController {
             // appropriate for use in test results.
             int slotIdentifier = result.getSlot().getId();
             if (!VALID_SLOTS.contains(slotIdentifier)) {
-                addFailure("6.1.12.2.a (A7.1.c) - #" + slotIdentifier + " SLOT identifier for SPN " + spnId + " from "
-                        + moduleName + " is invalid");
+                addFailure("6.1.12.2.a (A7.1.c) - #" + slotIdentifier + " SLOT identifier for SPN " + spnId
+                        + " FMI " + result.getFmi() + " from " + moduleName + " is invalid");
             }
         }
     }

--- a/src/org/etools/j1939_84/model/StepResult.java
+++ b/src/org/etools/j1939_84/model/StepResult.java
@@ -9,9 +9,8 @@ import static org.etools.j1939_84.model.Outcome.INCOMPLETE;
 import static org.etools.j1939_84.model.Outcome.INFO;
 import static org.etools.j1939_84.model.Outcome.WARN;
 
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * @author Matt Gumbel (matt@soliddesign.net)
@@ -19,7 +18,7 @@ import java.util.Set;
 public class StepResult implements IResult {
     private final String name;
     private final int partNumber;
-    private final Set<ActionOutcome> results = new HashSet<>();
+    private final Collection<ActionOutcome> results = new ArrayList<>();
     private final int stepNumber;
     private Outcome outcome;
 


### PR DESCRIPTION
Resolves #960 

Use a `List` instead of `Set` so duplicate `ActionOutcomes` will still be counted in the final report

Additionally, changed Test 1.12 text so the outcomes are reported differently