### PR TITLE
Fix #964 - False FAIL for VIN in 6.1.5.2e

### DIFF
--- a/src-test/org/etools/j1939_84/utils/VinDecoderTest.java
+++ b/src-test/org/etools/j1939_84/utils/VinDecoderTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2019. Equipment & Tool Institute
+/*
+ * Copyright (c) 2021. Equipment & Tool Institute
  */
 package org.etools.j1939_84.utils;
 
@@ -35,9 +35,9 @@ public class VinDecoderTest {
         assertEquals(2019, instance.getModelYear("RV2M3HLC8KRVY8256"));
         assertEquals(2020, instance.getModelYear("9R3SDLYJ2LE3A0368"));
         assertEquals(2021, instance.getModelYear("DY0TWE1J4MN9F3376"));
-        assertEquals(2022, instance.getModelYear("M828RYKLXNPB25823"));
+        assertEquals(2022, instance.getModelYear("NL9ULTLV3NMYB4983"));
         assertEquals(2023, instance.getModelYear("N7JDSGR32PSLS6495"));
-        assertEquals(2024, instance.getModelYear("HTVLG7V8XR0658779"));
+        assertEquals(2024, instance.getModelYear("EK4NM2M44RHK91867"));
         assertEquals(2025, instance.getModelYear("JDFKATNW2SNHE2645"));
         assertEquals(2026, instance.getModelYear("R37P8T4B0TD0W9194"));
         assertEquals(2027, instance.getModelYear("36JFM6U57VWJE6400"));
@@ -46,7 +46,7 @@ public class VinDecoderTest {
         assertEquals(2030, instance.getModelYear("K3CV77CM5Y58S3528"));
         assertEquals(2031, instance.getModelYear("8V0E8GDU81G132838"));
         assertEquals(2032, instance.getModelYear("MK4FDL0Y42K8Y9930"));
-        assertEquals(2033, instance.getModelYear("WZRTJ90MX3UWB3530"));
+        assertEquals(2033, instance.getModelYear("BS90RVXA63ZX55303"));
         assertEquals(2034, instance.getModelYear("CNH003FP34F285830"));
         assertEquals(2035, instance.getModelYear("2MRKRPW295S6V7673"));
         assertEquals(2036, instance.getModelYear("2Y9DWG7U96PPC9940"));
@@ -62,7 +62,7 @@ public class VinDecoderTest {
             + "<li>null</li>"
             + "<li>not 17 character</li>"
             + "<li>invalid characters</li>"
-            + "<li>invalid sequece</li>"
+            + "<li>invalid sequence</li>"
             + "<li>confirm test works with a valid VIN is detected as valid</li>"
             + "</ul>")
     public void testIsVinValid() {
@@ -85,6 +85,19 @@ public class VinDecoderTest {
         assertFalse("Non-numeric sequence", instance.isVinValid("PX0W9XD10RZL37HD7"));
 
         assertTrue("VIN is valid", instance.isVinValid("2G1WB5E37E1110567"));
+        assertTrue("VIN is valid", instance.isVinValid("1XPBDK9X1LD708195"));
+
+        assertTrue("Check Digit 0:", instance.isVinValid("38Z63P7W0GCRB5050"));
+        assertTrue("Check Digit 1:", instance.isVinValid("1VTAZ3NR1UZA70835"));
+        assertTrue("Check Digit 2:", instance.isVinValid("2UNLM4Y22KF0E2219"));
+        assertTrue("Check Digit 3:", instance.isVinValid("PBJ1GXMU3NDE71284"));
+        assertTrue("Check Digit 4:", instance.isVinValid("0C1H83214Y4JF6614"));
+        assertTrue("Check Digit 5:", instance.isVinValid("6DERGH2S587714324"));
+        assertTrue("Check Digit 6:", instance.isVinValid("U0Y2NM226JG9N5043"));
+        assertTrue("Check Digit 7:", instance.isVinValid("9BY7UYCC7210U3767"));
+        assertTrue("Check Digit 8:", instance.isVinValid("TT4GR5BH8EVNJ7856"));
+        assertTrue("Check Digit 9:", instance.isVinValid("3EA4ZN5H9CKJU9042"));
+        assertTrue("Check Digit X:", instance.isVinValid("N09EHGGTXUT589046"));
     }
 
     @Test

--- a/src-test/org/etools/j1939_84/utils/VinDecoderTest.java
+++ b/src-test/org/etools/j1939_84/utils/VinDecoderTest.java
@@ -86,9 +86,10 @@ public class VinDecoderTest {
 
         assertTrue("VIN is valid", instance.isVinValid("2G1WB5E37E1110567"));
         assertTrue("VIN is valid", instance.isVinValid("1XPBDK9X1LD708195"));
+        assertFalse("VIN is invalid with bad model year", instance.isVinValid("1VTAZ3NR1UZA70835"));
 
         assertTrue("Check Digit 0:", instance.isVinValid("38Z63P7W0GCRB5050"));
-        assertTrue("Check Digit 1:", instance.isVinValid("1VTAZ3NR1UZA70835"));
+        assertTrue("Check Digit 1:", instance.isVinValid("WYSHUV571C50P2806"));
         assertTrue("Check Digit 2:", instance.isVinValid("2UNLM4Y22KF0E2219"));
         assertTrue("Check Digit 3:", instance.isVinValid("PBJ1GXMU3NDE71284"));
         assertTrue("Check Digit 4:", instance.isVinValid("0C1H83214Y4JF6614"));
@@ -97,7 +98,7 @@ public class VinDecoderTest {
         assertTrue("Check Digit 7:", instance.isVinValid("9BY7UYCC7210U3767"));
         assertTrue("Check Digit 8:", instance.isVinValid("TT4GR5BH8EVNJ7856"));
         assertTrue("Check Digit 9:", instance.isVinValid("3EA4ZN5H9CKJU9042"));
-        assertTrue("Check Digit X:", instance.isVinValid("N09EHGGTXUT589046"));
+        assertTrue("Check Digit X:", instance.isVinValid("RYZA0YM5X5SJL1774"));
     }
 
     @Test

--- a/src/org/etools/j1939_84/utils/VinDecoder.java
+++ b/src/org/etools/j1939_84/utils/VinDecoder.java
@@ -17,10 +17,17 @@ public class VinDecoder {
 
     public static final int MAX_MODEL_YEAR = 2039;
     public static final int MIN_MODEL_YEAR = 2010;
+
     public static final int VIN_LENGTH = 17; // characters
-    private static final int[] LETTER_VALUE = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7,
-            8, 0, 1, 2, 3, 4, 5, 0, 7, 0, 9, 2, 3, 4, 5, 6, 7, 8, 9 };
+
+    // @formatter:off
+    private static final int[] LETTER_VALUE = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 0, 0, 0, 0, 0, 0,
+         // A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z
+            1, 2, 3, 4, 5, 6, 7, 8, 0, 1, 2, 3, 4, 5, 0, 7, 0, 9, 2, 3, 4, 5, 6, 7, 8, 9 };
+    // @formatter:on
+
     private static final Map<String, Integer> MODEL_YEARS = new HashMap<>();
+
     private static final int[] WEIGHT = { 8, 7, 6, 5, 4, 3, 2, 10, 0, 9, 8, 7, 6, 5, 4, 3, 2 };
 
     static {
@@ -68,7 +75,7 @@ public class VinDecoder {
             sum += LETTER_VALUE[vin.charAt(i) - '0'] * WEIGHT[i];
         }
         int checkSum = sum % 11;
-        return checkSum == 1 ? 'X' : (char) (checkSum + '0');
+        return checkSum == 10 ? 'X' : (char) (checkSum + '0');
     }
 
     /**

--- a/src/org/etools/j1939_84/utils/VinDecoder.java
+++ b/src/org/etools/j1939_84/utils/VinDecoder.java
@@ -87,12 +87,16 @@ public class VinDecoder {
      */
     public int getModelYear(String vin) {
         if (isVinValid(vin)) {
-            Integer result = MODEL_YEARS.get(Character.toString(vin.charAt(9)));
+            Integer result = getModelYearValue(vin);
             if (result != null) {
                 return result;
             }
         }
         return -1;
+    }
+
+    private Integer getModelYearValue(String vin) {
+        return MODEL_YEARS.get(Character.toString(vin.charAt(9)));
     }
 
     /**
@@ -120,6 +124,10 @@ public class VinDecoder {
 
         if (calculateCheckSum(sanitizedVin) != sanitizedVin.charAt(8)) {
             return false; // Bad Checksum
+        }
+
+        if (getModelYearValue(vin) == null) {
+            return false; // The model year is not valid
         }
 
         try {


### PR DESCRIPTION
Resolves #964 

The check digit should be 'X' when the `sum % 11 == 10`.  I also updated the tests to explicitly verify each check digit.