### PR TITLE
Fix #977 - Correct Test 1.14 DM26 Enable Bit Outcomes

### DIFF
--- a/src-test/org/etools/j1939_84/controllers/part01/Part01Step14ControllerTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/Part01Step14ControllerTest.java
@@ -4,7 +4,7 @@
 package org.etools.j1939_84.controllers.part01;
 
 import static org.etools.j1939_84.J1939_84.NL;
-import static org.etools.j1939_84.bus.j1939.packets.DM26TripDiagnosticReadinessPacket.PGN;
+import static org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket.Response.NACK;
 import static org.etools.j1939_84.model.Outcome.FAIL;
 import static org.etools.j1939_84.model.Outcome.WARN;
 import static org.junit.Assert.assertEquals;
@@ -14,15 +14,16 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.concurrent.Executor;
 
-import org.etools.j1939_84.bus.Packet;
 import org.etools.j1939_84.bus.j1939.J1939;
+import org.etools.j1939_84.bus.j1939.packets.AcknowledgmentPacket;
+import org.etools.j1939_84.bus.j1939.packets.CompositeSystem;
 import org.etools.j1939_84.bus.j1939.packets.DM26TripDiagnosticReadinessPacket;
 import org.etools.j1939_84.bus.j1939.packets.DM5DiagnosticReadinessPacket;
 import org.etools.j1939_84.controllers.DataRepository;
 import org.etools.j1939_84.controllers.ResultsListener;
-import org.etools.j1939_84.controllers.StepController;
 import org.etools.j1939_84.controllers.TestResultsListener;
 import org.etools.j1939_84.model.OBDModuleInformation;
 import org.etools.j1939_84.model.RequestResult;
@@ -116,13 +117,85 @@ public class Part01Step14ControllerTest extends AbstractControllerTest {
                                  mockListener);
     }
 
-    /**
-     * Test method for
-     * {@link Part01Step14Controller#run()}.
-     */
     @Test
-    public void testEmptyPacketFailure() {
+    public void testGetDisplayName() {
+        assertEquals("Part " + PART_NUMBER + " Step " + STEP_NUMBER, instance.getDisplayName());
+    }
 
+    @Test
+    public void testGetStepNumber() {
+        assertEquals(STEP_NUMBER, instance.getStepNumber());
+    }
+
+    @Test
+    public void testGetTotalSteps() {
+        assertEquals("Total Steps", 0, instance.getTotalSteps());
+    }
+
+    @Test
+    public void testHappyPathNoFailures() {
+        var enabledSystems = List.of(
+                                     CompositeSystem.AC_SYSTEM_REFRIGERANT,
+                                     CompositeSystem.BOOST_PRESSURE_CONTROL_SYS,
+                                     CompositeSystem.CATALYST,
+                                     CompositeSystem.COMPREHENSIVE_COMPONENT,
+                                     CompositeSystem.DIESEL_PARTICULATE_FILTER,
+                                     CompositeSystem.EVAPORATIVE_SYSTEM,
+                                     CompositeSystem.EXHAUST_GAS_SENSOR_HEATER);
+        var completeSystems = List.of(
+                                      CompositeSystem.COLD_START_AID_SYSTEM,
+                                      CompositeSystem.EGR_VVT_SYSTEM,
+                                      CompositeSystem.FUEL_SYSTEM,
+                                      CompositeSystem.MISFIRE,
+                                      CompositeSystem.NMHC_CONVERTING_CATALYST,
+                                      CompositeSystem.SECONDARY_AIR_SYSTEM,
+                                      CompositeSystem.NOX_CATALYST_ABSORBER,
+                                      CompositeSystem.EXHAUST_GAS_SENSOR,
+                                      CompositeSystem.HEATED_CATALYST);
+        var dm26 = DM26TripDiagnosticReadinessPacket.create(0, 0, 0, enabledSystems, completeSystems);
+
+        OBDModuleInformation obdModule = new OBDModuleInformation(0);
+        obdModule.set(DM5DiagnosticReadinessPacket.create(0, 0, 0, 0x22, enabledSystems, completeSystems), 1);
+        dataRepository.putObdModule(obdModule);
+        when(diagnosticMessageModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26));
+
+        dataRepository.putObdModule(new OBDModuleInformation(1));
+        var nack = AcknowledgmentPacket.create(1, NACK);
+        when(diagnosticMessageModule.requestDM26(any(), eq(1))).thenReturn(new RequestResult<>(false, nack));
+
+        when(diagnosticMessageModule.requestDM26(any())).thenReturn(RequestResult.of(dm26));
+
+        runTest();
+
+        verify(diagnosticMessageModule).setJ1939(j1939);
+        verify(diagnosticMessageModule).requestDM26(any());
+        verify(diagnosticMessageModule).requestDM26(any(), eq(0));
+        verify(diagnosticMessageModule).requestDM26(any(), eq(1));
+
+        String expectedResults = NL + "Vehicle Composite of DM26:" + NL;
+        expectedResults += "    A/C system refrigerant         enabled, not complete" + NL;
+        expectedResults += "    Boost pressure control sys     enabled, not complete" + NL;
+        expectedResults += "    Catalyst                       enabled, not complete" + NL;
+        expectedResults += "    Cold start aid system      not enabled,     complete" + NL;
+        expectedResults += "    Comprehensive component        enabled, not complete" + NL;
+        expectedResults += "    Diesel Particulate Filter      enabled, not complete" + NL;
+        expectedResults += "    EGR/VVT system             not enabled,     complete" + NL;
+        expectedResults += "    Evaporative system             enabled, not complete" + NL;
+        expectedResults += "    Exhaust Gas Sensor         not enabled,     complete" + NL;
+        expectedResults += "    Exhaust Gas Sensor heater      enabled, not complete" + NL;
+        expectedResults += "    Fuel System                not enabled,     complete" + NL;
+        expectedResults += "    Heated catalyst            not enabled,     complete" + NL;
+        expectedResults += "    Misfire                    not enabled,     complete" + NL;
+        expectedResults += "    NMHC converting catalyst   not enabled,     complete" + NL;
+        expectedResults += "    NOx catalyst/adsorber      not enabled,     complete" + NL;
+        expectedResults += "    Secondary air system       not enabled,     complete" + NL;
+        expectedResults += NL;
+        assertEquals(expectedResults, listener.getResults());
+        assertEquals(List.of(), listener.getOutcomes());
+    }
+
+    @Test
+    public void testFailureForNoDm26() {
         when(diagnosticMessageModule.requestDM26(any())).thenReturn(RequestResult.empty());
 
         runTest();
@@ -130,200 +203,47 @@ public class Part01Step14ControllerTest extends AbstractControllerTest {
         verify(diagnosticMessageModule).setJ1939(j1939);
         verify(diagnosticMessageModule).requestDM26(any());
 
-        verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL, "6.1.14.2.e - No OBD ECU provided DM26");
+        verify(mockListener).addOutcome(PART_NUMBER, STEP_NUMBER, FAIL, "6.1.14.2.f - No OBD ECU provided DM26");
 
         assertEquals("", listener.getResults());
         assertEquals("", listener.getMessages());
     }
 
     @Test
-    public void testFailures() {
-        Packet packet1Packet = Packet.create(PGN, 0x01, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88);
-        DM26TripDiagnosticReadinessPacket packet1 = new DM26TripDiagnosticReadinessPacket(packet1Packet);
-        OBDModuleInformation obdModule1 = new OBDModuleInformation(0x01);
-        obdModule1.set(new DM5DiagnosticReadinessPacket(packet1Packet), 1);
-        dataRepository.putObdModule(obdModule1);
-        when(diagnosticMessageModule.requestDM26(any(), eq(0x01))).thenReturn(RequestResult.of(packet1));
+    public void testFailureForSupportedNotComplete() {
+        var enabledSystems = List.of(
+                                     CompositeSystem.AC_SYSTEM_REFRIGERANT,
+                                     CompositeSystem.BOOST_PRESSURE_CONTROL_SYS,
+                                     CompositeSystem.CATALYST,
+                                     CompositeSystem.COMPREHENSIVE_COMPONENT,
+                                     CompositeSystem.DIESEL_PARTICULATE_FILTER,
+                                     CompositeSystem.EVAPORATIVE_SYSTEM,
+                                     CompositeSystem.EXHAUST_GAS_SENSOR_HEATER);
+        var completeSystems = List.of(
+                                      CompositeSystem.BOOST_PRESSURE_CONTROL_SYS,
+                                      CompositeSystem.COLD_START_AID_SYSTEM,
+                                      CompositeSystem.EGR_VVT_SYSTEM,
+                                      CompositeSystem.FUEL_SYSTEM,
+                                      CompositeSystem.MISFIRE,
+                                      CompositeSystem.NMHC_CONVERTING_CATALYST,
+                                      CompositeSystem.SECONDARY_AIR_SYSTEM,
+                                      CompositeSystem.NOX_CATALYST_ABSORBER,
+                                      CompositeSystem.EXHAUST_GAS_SENSOR,
+                                      CompositeSystem.HEATED_CATALYST);
+        var dm26 = DM26TripDiagnosticReadinessPacket.create(0, 0, 0, enabledSystems, completeSystems);
 
-        Packet packet3Packet = Packet.create(PGN, 0x03, 0x00, 0x00, 0x04, 0x00, 0xFF, 0xFF, 0xFF, 0xFF);
-        DM26TripDiagnosticReadinessPacket packet3 = new DM26TripDiagnosticReadinessPacket(packet3Packet);
+        OBDModuleInformation obdModule = new OBDModuleInformation(0);
+        obdModule.set(DM5DiagnosticReadinessPacket.create(0, 0, 0, 0x22, enabledSystems, completeSystems), 1);
+        dataRepository.putObdModule(obdModule);
 
-        Packet obdPacket3Packet = Packet.create(PGN, 0x03, 0x11, 0x22, 0x13, 0x44, 0x55, 0x66, 0x77, 0x88);
-        DM26TripDiagnosticReadinessPacket obdPacket3 = new DM26TripDiagnosticReadinessPacket(obdPacket3Packet);
-
-        OBDModuleInformation obdModule3 = new OBDModuleInformation(0x03);
-        obdModule3.set(new DM5DiagnosticReadinessPacket(obdPacket3Packet), 1);
-        dataRepository.putObdModule(obdModule3);
-        when(diagnosticMessageModule.requestDM26(any(), eq(0x03))).thenReturn(RequestResult.of(obdPacket3));
-
-        when(diagnosticMessageModule.requestDM26(any())).thenReturn(RequestResult.of(packet1, packet3));
-
-        runTest();
-
-        verify(diagnosticMessageModule).setJ1939(j1939);
-        verify(diagnosticMessageModule).requestDM26(any());
-        verify(diagnosticMessageModule).requestDM26(any(), eq(0x01));
-        verify(diagnosticMessageModule).requestDM26(any(), eq(0x03));
-
-        verify(mockListener).addOutcome(
-                                        1,
-                                        14,
-                                        FAIL,
-                                        "6.1.14.2.b - Transmission #1 (3) response for a monitor NOx catalyst/adsorber in DM5 is reported as not supported and is reported as enabled by DM26 response");
-        verify(mockListener).addOutcome(
-                                        1,
-                                        14,
-                                        FAIL,
-                                        "6.1.14.2.b - Transmission #1 (3) response for a monitor Secondary air system in DM5 is reported as not supported and is reported as enabled by DM26 response");
-        verify(mockListener).addOutcome(
-                                        1,
-                                        14,
-                                        FAIL,
-                                        "6.1.14.2.b - Transmission #1 (3) response for a monitor NMHC converting catalyst in DM5 is reported as not supported and is reported as enabled by DM26 response");
-        verify(mockListener).addOutcome(
-                                        1,
-                                        14,
-                                        FAIL,
-                                        "6.1.14.2.b - Transmission #1 (3) response for a monitor Cold start aid system in DM5 is reported as not supported and is reported as enabled by DM26 response");
-        verify(mockListener).addOutcome(
-                                        1,
-                                        14,
-                                        FAIL,
-                                        "6.1.14.2.b - Transmission #1 (3) response for a monitor Exhaust Gas Sensor in DM5 is reported as not supported and is reported as enabled by DM26 response");
-        verify(mockListener).addOutcome(
-                                        1,
-                                        14,
-                                        FAIL,
-                                        "6.1.14.2.b - Transmission #1 (3) response for a monitor EGR/VVT system in DM5 is reported as not supported and is reported as enabled by DM26 response");
-        verify(mockListener).addOutcome(
-                                        1,
-                                        14,
-                                        FAIL,
-                                        "6.1.14.2.b - Transmission #1 (3) response for a monitor Heated catalyst in DM5 is reported as not supported and is reported as enabled by DM26 response");
-        verify(mockListener).addOutcome(
-                                        1,
-                                        14,
-                                        FAIL,
-                                        "6.1.14.2.c - Engine #2 (1) response indicates number of warm-ups since code clear is not zero");
-        verify(mockListener).addOutcome(
-                                        1,
-                                        14,
-                                        FAIL,
-                                        "6.1.14.2.c - Transmission #1 (3) response indicates number of warm-ups since code clear is not zero");
-        verify(mockListener).addOutcome(
-                                        1,
-                                        14,
-                                        FAIL,
-                                        "6.1.14.2.d - Engine #2 (1) response indicates time since engine start is not zero");
-        verify(mockListener).addOutcome(
-                                        1,
-                                        14,
-                                        WARN,
-                                        "6.1.14.3.a - Required monitor A/C system refrigerant is supported by more than one OBD ECU");
-        verify(mockListener).addOutcome(
-                                        1,
-                                        14,
-                                        WARN,
-                                        "6.1.14.3.a - Required monitor Boost pressure control sys is supported by more than one OBD ECU");
-        verify(mockListener).addOutcome(
-                                        1,
-                                        14,
-                                        WARN,
-                                        "6.1.14.3.a - Required monitor Catalyst is supported by more than one OBD ECU");
-        verify(mockListener).addOutcome(
-                                        1,
-                                        14,
-                                        WARN,
-                                        "6.1.14.3.a - Required monitor Diesel Particulate Filter is supported by more than one OBD ECU");
-        verify(mockListener).addOutcome(
-                                        1,
-                                        14,
-                                        WARN,
-                                        "6.1.14.3.a - Required monitor Evaporative system is supported by more than one OBD ECU");
-        verify(mockListener).addOutcome(
-                                        1,
-                                        14,
-                                        WARN,
-                                        "6.1.14.3.a - Required monitor Exhaust Gas Sensor heater is supported by more than one OBD ECU");
-        verify(mockListener).addOutcome(
-                                        1,
-                                        14,
-                                        FAIL,
-                                        "6.1.14.5.a - Difference compared to data received during global request from Transmission #1 (3)");
-
-        String expectedResults = "" + NL;
-        expectedResults += "Vehicle Composite of DM26:" + NL;
-        expectedResults += "    A/C system refrigerant         enabled, not complete" + NL;
-        expectedResults += "    Boost pressure control sys     enabled, not complete" + NL;
-        expectedResults += "    Catalyst                       enabled, not complete" + NL;
-        expectedResults += "    Cold start aid system          enabled, not complete" + NL;
-        expectedResults += "    Comprehensive component        enabled, not complete" + NL;
-        expectedResults += "    Diesel Particulate Filter      enabled, not complete" + NL;
-        expectedResults += "    EGR/VVT system                 enabled, not complete" + NL;
-        expectedResults += "    Evaporative system             enabled, not complete" + NL;
-        expectedResults += "    Exhaust Gas Sensor             enabled, not complete" + NL;
-        expectedResults += "    Exhaust Gas Sensor heater      enabled, not complete" + NL;
-        expectedResults += "    Fuel System                not enabled,     complete" + NL;
-        expectedResults += "    Heated catalyst                enabled, not complete" + NL;
-        expectedResults += "    Misfire                    not enabled,     complete" + NL;
-        expectedResults += "    NMHC converting catalyst       enabled, not complete" + NL;
-        expectedResults += "    NOx catalyst/adsorber          enabled, not complete" + NL;
-        expectedResults += "    Secondary air system           enabled, not complete" + NL;
-        expectedResults += NL;
-
-        assertEquals(expectedResults, listener.getResults());
-    }
-
-    /**
-     * Test method for
-     * {@link StepController#getDisplayName()}.
-     */
-    @Test
-    public void testGetDisplayName() {
-        String name = "Part " + PART_NUMBER + " Step " + STEP_NUMBER;
-        assertEquals("Display Name", name, instance.getDisplayName());
-    }
-
-    /**
-     * Test method for
-     * {@link Part01Step14Controller#getStepNumber()}.
-     */
-    @Test
-    public void testGetStepNumber() {
-        assertEquals(STEP_NUMBER, instance.getStepNumber());
-    }
-
-    /**
-     * Test method for
-     * {@link StepController#getTotalSteps()}.
-     */
-    @Test
-    public void testGetTotalSteps() {
-        assertEquals("Total Steps", 0, instance.getTotalSteps());
-    }
-
-    /**
-     * Test method for
-     * {@link Part01Step14Controller#run()}.
-     */
-    @Test
-    public void testRun() {
-
-        Packet packet1Packet = Packet.create(PGN, 0x01, 0x00, 0x00, 0x00, 0x44, 0x55, 0x66, 0x77, 0x88);
-        DM26TripDiagnosticReadinessPacket packet1 = new DM26TripDiagnosticReadinessPacket(packet1Packet);
-
-        OBDModuleInformation obdModule1 = new OBDModuleInformation(0x01);
-        obdModule1.set(new DM5DiagnosticReadinessPacket(packet1Packet), 1);
-        dataRepository.putObdModule(obdModule1);
-
-        when(diagnosticMessageModule.requestDM26(any())).thenReturn(RequestResult.of(packet1));
-        when(diagnosticMessageModule.requestDM26(any(), eq(0x01))).thenReturn(RequestResult.of(packet1));
+        when(diagnosticMessageModule.requestDM26(any())).thenReturn(RequestResult.of(dm26));
+        when(diagnosticMessageModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26));
 
         runTest();
 
         verify(diagnosticMessageModule).setJ1939(j1939);
         verify(diagnosticMessageModule).requestDM26(any());
-        verify(diagnosticMessageModule).requestDM26(any(), eq(0x01));
+        verify(diagnosticMessageModule).requestDM26(any(), eq(0));
 
         String expectedResults = NL + "Vehicle Composite of DM26:" + NL;
         expectedResults += "    A/C system refrigerant         enabled, not complete" + NL;
@@ -331,18 +251,535 @@ public class Part01Step14ControllerTest extends AbstractControllerTest {
         expectedResults += "    Catalyst                       enabled, not complete" + NL;
         expectedResults += "    Cold start aid system      not enabled,     complete" + NL;
         expectedResults += "    Comprehensive component        enabled, not complete" + NL;
-        expectedResults += "    Diesel Particulate Filter      enabled,     complete" + NL;
+        expectedResults += "    Diesel Particulate Filter      enabled, not complete" + NL;
         expectedResults += "    EGR/VVT system             not enabled,     complete" + NL;
         expectedResults += "    Evaporative system             enabled, not complete" + NL;
-        expectedResults += "    Exhaust Gas Sensor         not enabled, not complete" + NL;
+        expectedResults += "    Exhaust Gas Sensor         not enabled,     complete" + NL;
         expectedResults += "    Exhaust Gas Sensor heater      enabled, not complete" + NL;
         expectedResults += "    Fuel System                not enabled,     complete" + NL;
-        expectedResults += "    Heated catalyst            not enabled, not complete" + NL;
+        expectedResults += "    Heated catalyst            not enabled,     complete" + NL;
         expectedResults += "    Misfire                    not enabled,     complete" + NL;
         expectedResults += "    NMHC converting catalyst   not enabled,     complete" + NL;
-        expectedResults += "    NOx catalyst/adsorber      not enabled, not complete" + NL;
+        expectedResults += "    NOx catalyst/adsorber      not enabled,     complete" + NL;
         expectedResults += "    Secondary air system       not enabled,     complete" + NL;
         expectedResults += NL;
         assertEquals(expectedResults, listener.getResults());
+
+        verify(mockListener).addOutcome(PART_NUMBER,
+                                        STEP_NUMBER,
+                                        FAIL,
+                                        "6.1.14.2.a - Engine #1 (0) response for a monitor Boost pressure control sys in DM5 is reported as supported and is reported as complete/not supported DM26 response");
+    }
+
+    @Test
+    public void testFailureForDisabledAndNotDisabled() {
+        var dm26EnabledSystems = List.of(
+                                         CompositeSystem.AC_SYSTEM_REFRIGERANT,
+                                         CompositeSystem.BOOST_PRESSURE_CONTROL_SYS,
+                                         CompositeSystem.CATALYST,
+                                         CompositeSystem.COMPREHENSIVE_COMPONENT,
+                                         CompositeSystem.DIESEL_PARTICULATE_FILTER,
+                                         CompositeSystem.EVAPORATIVE_SYSTEM,
+                                         CompositeSystem.EXHAUST_GAS_SENSOR_HEATER);
+        var completeSystems = List.of(
+                                      CompositeSystem.COLD_START_AID_SYSTEM,
+                                      CompositeSystem.EGR_VVT_SYSTEM,
+                                      CompositeSystem.FUEL_SYSTEM,
+                                      CompositeSystem.MISFIRE,
+                                      CompositeSystem.NMHC_CONVERTING_CATALYST,
+                                      CompositeSystem.SECONDARY_AIR_SYSTEM,
+                                      CompositeSystem.NOX_CATALYST_ABSORBER,
+                                      CompositeSystem.EXHAUST_GAS_SENSOR,
+                                      CompositeSystem.HEATED_CATALYST);
+        var dm26 = DM26TripDiagnosticReadinessPacket.create(0, 0, 0, dm26EnabledSystems, completeSystems);
+
+        OBDModuleInformation obdModule = new OBDModuleInformation(0);
+        var dm5SupportedSystem = List.of(
+                                         CompositeSystem.AC_SYSTEM_REFRIGERANT,
+                                         CompositeSystem.BOOST_PRESSURE_CONTROL_SYS,
+                                         CompositeSystem.COMPREHENSIVE_COMPONENT,
+                                         CompositeSystem.DIESEL_PARTICULATE_FILTER,
+                                         CompositeSystem.EVAPORATIVE_SYSTEM,
+                                         CompositeSystem.EXHAUST_GAS_SENSOR_HEATER);
+        obdModule.set(DM5DiagnosticReadinessPacket.create(0, 0, 0, 0x22, dm5SupportedSystem, completeSystems), 1);
+        dataRepository.putObdModule(obdModule);
+
+        when(diagnosticMessageModule.requestDM26(any())).thenReturn(RequestResult.of(dm26));
+        when(diagnosticMessageModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26));
+
+        runTest();
+
+        verify(diagnosticMessageModule).setJ1939(j1939);
+        verify(diagnosticMessageModule).requestDM26(any());
+        verify(diagnosticMessageModule).requestDM26(any(), eq(0));
+
+        String expectedResults = NL + "Vehicle Composite of DM26:" + NL;
+        expectedResults += "    A/C system refrigerant         enabled, not complete" + NL;
+        expectedResults += "    Boost pressure control sys     enabled, not complete" + NL;
+        expectedResults += "    Catalyst                       enabled, not complete" + NL;
+        expectedResults += "    Cold start aid system      not enabled,     complete" + NL;
+        expectedResults += "    Comprehensive component        enabled, not complete" + NL;
+        expectedResults += "    Diesel Particulate Filter      enabled, not complete" + NL;
+        expectedResults += "    EGR/VVT system             not enabled,     complete" + NL;
+        expectedResults += "    Evaporative system             enabled, not complete" + NL;
+        expectedResults += "    Exhaust Gas Sensor         not enabled,     complete" + NL;
+        expectedResults += "    Exhaust Gas Sensor heater      enabled, not complete" + NL;
+        expectedResults += "    Fuel System                not enabled,     complete" + NL;
+        expectedResults += "    Heated catalyst            not enabled,     complete" + NL;
+        expectedResults += "    Misfire                    not enabled,     complete" + NL;
+        expectedResults += "    NMHC converting catalyst   not enabled,     complete" + NL;
+        expectedResults += "    NOx catalyst/adsorber      not enabled,     complete" + NL;
+        expectedResults += "    Secondary air system       not enabled,     complete" + NL;
+        expectedResults += NL;
+        assertEquals(expectedResults, listener.getResults());
+        verify(mockListener).addOutcome(PART_NUMBER,
+                                        STEP_NUMBER,
+                                        FAIL,
+                                        "6.1.14.2.b - Engine #1 (0) response for a monitor Catalyst in DM5 is reported as not supported and is not reported as disabled and complete/not supported by DM26 response");
+    }
+
+    @Test
+    public void testFailureForDisabledAndNotComplete() {
+        var enabledSystems = List.of(
+                                     CompositeSystem.AC_SYSTEM_REFRIGERANT,
+                                     CompositeSystem.BOOST_PRESSURE_CONTROL_SYS,
+                                     CompositeSystem.CATALYST,
+                                     CompositeSystem.COMPREHENSIVE_COMPONENT,
+                                     CompositeSystem.DIESEL_PARTICULATE_FILTER,
+                                     CompositeSystem.EVAPORATIVE_SYSTEM,
+                                     CompositeSystem.EXHAUST_GAS_SENSOR_HEATER);
+        var completeSystems = List.of(
+                                      CompositeSystem.EGR_VVT_SYSTEM,
+                                      CompositeSystem.FUEL_SYSTEM,
+                                      CompositeSystem.MISFIRE,
+                                      CompositeSystem.NMHC_CONVERTING_CATALYST,
+                                      CompositeSystem.SECONDARY_AIR_SYSTEM,
+                                      CompositeSystem.NOX_CATALYST_ABSORBER,
+                                      CompositeSystem.EXHAUST_GAS_SENSOR,
+                                      CompositeSystem.HEATED_CATALYST);
+        var dm26 = DM26TripDiagnosticReadinessPacket.create(0, 0, 0, enabledSystems, completeSystems);
+
+        OBDModuleInformation obdModule = new OBDModuleInformation(0);
+        obdModule.set(DM5DiagnosticReadinessPacket.create(0, 0, 0, 0x22, enabledSystems, completeSystems), 1);
+        dataRepository.putObdModule(obdModule);
+
+        when(diagnosticMessageModule.requestDM26(any())).thenReturn(RequestResult.of(dm26));
+        when(diagnosticMessageModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26));
+
+        runTest();
+
+        verify(diagnosticMessageModule).setJ1939(j1939);
+        verify(diagnosticMessageModule).requestDM26(any());
+        verify(diagnosticMessageModule).requestDM26(any(), eq(0));
+
+        String expectedResults = NL + "Vehicle Composite of DM26:" + NL;
+        expectedResults += "    A/C system refrigerant         enabled, not complete" + NL;
+        expectedResults += "    Boost pressure control sys     enabled, not complete" + NL;
+        expectedResults += "    Catalyst                       enabled, not complete" + NL;
+        expectedResults += "    Cold start aid system      not enabled, not complete" + NL;
+        expectedResults += "    Comprehensive component        enabled, not complete" + NL;
+        expectedResults += "    Diesel Particulate Filter      enabled, not complete" + NL;
+        expectedResults += "    EGR/VVT system             not enabled,     complete" + NL;
+        expectedResults += "    Evaporative system             enabled, not complete" + NL;
+        expectedResults += "    Exhaust Gas Sensor         not enabled,     complete" + NL;
+        expectedResults += "    Exhaust Gas Sensor heater      enabled, not complete" + NL;
+        expectedResults += "    Fuel System                not enabled,     complete" + NL;
+        expectedResults += "    Heated catalyst            not enabled,     complete" + NL;
+        expectedResults += "    Misfire                    not enabled,     complete" + NL;
+        expectedResults += "    NMHC converting catalyst   not enabled,     complete" + NL;
+        expectedResults += "    NOx catalyst/adsorber      not enabled,     complete" + NL;
+        expectedResults += "    Secondary air system       not enabled,     complete" + NL;
+        expectedResults += NL;
+        assertEquals(expectedResults, listener.getResults());
+        verify(mockListener).addOutcome(PART_NUMBER,
+                                        STEP_NUMBER,
+                                        FAIL,
+                                        "6.1.14.2.b - Engine #1 (0) response for a monitor Cold start aid system in DM5 is reported as not supported and is not reported as disabled and complete/not supported by DM26 response");
+    }
+
+    @Test
+    public void testFailureForDisabledCCM() {
+        var dm26EnabledSystems = List.of(
+                                         CompositeSystem.AC_SYSTEM_REFRIGERANT,
+                                         CompositeSystem.BOOST_PRESSURE_CONTROL_SYS,
+                                         CompositeSystem.CATALYST,
+                                         CompositeSystem.DIESEL_PARTICULATE_FILTER,
+                                         CompositeSystem.EVAPORATIVE_SYSTEM,
+                                         CompositeSystem.EXHAUST_GAS_SENSOR_HEATER);
+        var completeSystems = List.of(
+                                      CompositeSystem.COLD_START_AID_SYSTEM,
+                                      CompositeSystem.EGR_VVT_SYSTEM,
+                                      CompositeSystem.FUEL_SYSTEM,
+                                      CompositeSystem.MISFIRE,
+                                      CompositeSystem.NMHC_CONVERTING_CATALYST,
+                                      CompositeSystem.SECONDARY_AIR_SYSTEM,
+                                      CompositeSystem.NOX_CATALYST_ABSORBER,
+                                      CompositeSystem.EXHAUST_GAS_SENSOR,
+                                      CompositeSystem.HEATED_CATALYST);
+        var dm26 = DM26TripDiagnosticReadinessPacket.create(0, 0, 0, dm26EnabledSystems, completeSystems);
+
+        OBDModuleInformation obdModule = new OBDModuleInformation(0);
+        var dm5SupportedSystems = List.of(
+                                          CompositeSystem.AC_SYSTEM_REFRIGERANT,
+                                          CompositeSystem.BOOST_PRESSURE_CONTROL_SYS,
+                                          CompositeSystem.CATALYST,
+                                          CompositeSystem.COMPREHENSIVE_COMPONENT,
+                                          CompositeSystem.DIESEL_PARTICULATE_FILTER,
+                                          CompositeSystem.EVAPORATIVE_SYSTEM,
+                                          CompositeSystem.EXHAUST_GAS_SENSOR_HEATER);
+        obdModule.set(DM5DiagnosticReadinessPacket.create(0, 0, 0, 0x22, dm5SupportedSystems, completeSystems), 1);
+        dataRepository.putObdModule(obdModule);
+
+        when(diagnosticMessageModule.requestDM26(any())).thenReturn(RequestResult.of(dm26));
+        when(diagnosticMessageModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26));
+
+        runTest();
+
+        verify(diagnosticMessageModule).setJ1939(j1939);
+        verify(diagnosticMessageModule).requestDM26(any());
+        verify(diagnosticMessageModule).requestDM26(any(), eq(0));
+
+        String expectedResults = NL + "Vehicle Composite of DM26:" + NL;
+        expectedResults += "    A/C system refrigerant         enabled, not complete" + NL;
+        expectedResults += "    Boost pressure control sys     enabled, not complete" + NL;
+        expectedResults += "    Catalyst                       enabled, not complete" + NL;
+        expectedResults += "    Cold start aid system      not enabled,     complete" + NL;
+        expectedResults += "    Comprehensive component    not enabled, not complete" + NL;
+        expectedResults += "    Diesel Particulate Filter      enabled, not complete" + NL;
+        expectedResults += "    EGR/VVT system             not enabled,     complete" + NL;
+        expectedResults += "    Evaporative system             enabled, not complete" + NL;
+        expectedResults += "    Exhaust Gas Sensor         not enabled,     complete" + NL;
+        expectedResults += "    Exhaust Gas Sensor heater      enabled, not complete" + NL;
+        expectedResults += "    Fuel System                not enabled,     complete" + NL;
+        expectedResults += "    Heated catalyst            not enabled,     complete" + NL;
+        expectedResults += "    Misfire                    not enabled,     complete" + NL;
+        expectedResults += "    NMHC converting catalyst   not enabled,     complete" + NL;
+        expectedResults += "    NOx catalyst/adsorber      not enabled,     complete" + NL;
+        expectedResults += "    Secondary air system       not enabled,     complete" + NL;
+        expectedResults += NL;
+        assertEquals(expectedResults, listener.getResults());
+
+        verify(mockListener).addOutcome(PART_NUMBER,
+                                        STEP_NUMBER,
+                                        FAIL,
+                                        "6.1.14.2.c - Engine #1 (0) response for a monitor Comprehensive component in DM5 is reported as supported and is reported as disabled/not supported by DM26 response");
+    }
+
+    @Test
+    public void testFailureForNonZeroWarmups() {
+        var enabledSystems = List.of(
+                                     CompositeSystem.AC_SYSTEM_REFRIGERANT,
+                                     CompositeSystem.BOOST_PRESSURE_CONTROL_SYS,
+                                     CompositeSystem.CATALYST,
+                                     CompositeSystem.COMPREHENSIVE_COMPONENT,
+                                     CompositeSystem.DIESEL_PARTICULATE_FILTER,
+                                     CompositeSystem.EVAPORATIVE_SYSTEM,
+                                     CompositeSystem.EXHAUST_GAS_SENSOR_HEATER);
+        var completeSystems = List.of(
+                                      CompositeSystem.COLD_START_AID_SYSTEM,
+                                      CompositeSystem.EGR_VVT_SYSTEM,
+                                      CompositeSystem.FUEL_SYSTEM,
+                                      CompositeSystem.MISFIRE,
+                                      CompositeSystem.NMHC_CONVERTING_CATALYST,
+                                      CompositeSystem.SECONDARY_AIR_SYSTEM,
+                                      CompositeSystem.NOX_CATALYST_ABSORBER,
+                                      CompositeSystem.EXHAUST_GAS_SENSOR,
+                                      CompositeSystem.HEATED_CATALYST);
+        var dm26 = DM26TripDiagnosticReadinessPacket.create(0, 0, 1, enabledSystems, completeSystems);
+
+        OBDModuleInformation obdModule = new OBDModuleInformation(0);
+        obdModule.set(DM5DiagnosticReadinessPacket.create(0, 0, 0, 0x22, enabledSystems, completeSystems), 1);
+        dataRepository.putObdModule(obdModule);
+
+        when(diagnosticMessageModule.requestDM26(any())).thenReturn(RequestResult.of(dm26));
+        when(diagnosticMessageModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26));
+
+        runTest();
+
+        verify(diagnosticMessageModule).setJ1939(j1939);
+        verify(diagnosticMessageModule).requestDM26(any());
+        verify(diagnosticMessageModule).requestDM26(any(), eq(0));
+
+        String expectedResults = NL + "Vehicle Composite of DM26:" + NL;
+        expectedResults += "    A/C system refrigerant         enabled, not complete" + NL;
+        expectedResults += "    Boost pressure control sys     enabled, not complete" + NL;
+        expectedResults += "    Catalyst                       enabled, not complete" + NL;
+        expectedResults += "    Cold start aid system      not enabled,     complete" + NL;
+        expectedResults += "    Comprehensive component        enabled, not complete" + NL;
+        expectedResults += "    Diesel Particulate Filter      enabled, not complete" + NL;
+        expectedResults += "    EGR/VVT system             not enabled,     complete" + NL;
+        expectedResults += "    Evaporative system             enabled, not complete" + NL;
+        expectedResults += "    Exhaust Gas Sensor         not enabled,     complete" + NL;
+        expectedResults += "    Exhaust Gas Sensor heater      enabled, not complete" + NL;
+        expectedResults += "    Fuel System                not enabled,     complete" + NL;
+        expectedResults += "    Heated catalyst            not enabled,     complete" + NL;
+        expectedResults += "    Misfire                    not enabled,     complete" + NL;
+        expectedResults += "    NMHC converting catalyst   not enabled,     complete" + NL;
+        expectedResults += "    NOx catalyst/adsorber      not enabled,     complete" + NL;
+        expectedResults += "    Secondary air system       not enabled,     complete" + NL;
+        expectedResults += NL;
+        assertEquals(expectedResults, listener.getResults());
+
+        verify(mockListener).addOutcome(PART_NUMBER,
+                                        STEP_NUMBER,
+                                        FAIL,
+                                        "6.1.14.2.d - Engine #1 (0) response indicates number of warm-ups since code clear is not zero");
+    }
+
+    @Test
+    public void testFailureForNonZeroTSES() {
+        var enabledSystems = List.of(
+                                     CompositeSystem.AC_SYSTEM_REFRIGERANT,
+                                     CompositeSystem.BOOST_PRESSURE_CONTROL_SYS,
+                                     CompositeSystem.CATALYST,
+                                     CompositeSystem.COMPREHENSIVE_COMPONENT,
+                                     CompositeSystem.DIESEL_PARTICULATE_FILTER,
+                                     CompositeSystem.EVAPORATIVE_SYSTEM,
+                                     CompositeSystem.EXHAUST_GAS_SENSOR_HEATER);
+        var completeSystems = List.of(
+                                      CompositeSystem.COLD_START_AID_SYSTEM,
+                                      CompositeSystem.EGR_VVT_SYSTEM,
+                                      CompositeSystem.FUEL_SYSTEM,
+                                      CompositeSystem.MISFIRE,
+                                      CompositeSystem.NMHC_CONVERTING_CATALYST,
+                                      CompositeSystem.SECONDARY_AIR_SYSTEM,
+                                      CompositeSystem.NOX_CATALYST_ABSORBER,
+                                      CompositeSystem.EXHAUST_GAS_SENSOR,
+                                      CompositeSystem.HEATED_CATALYST);
+        var dm26 = DM26TripDiagnosticReadinessPacket.create(0, 1, 0, enabledSystems, completeSystems);
+
+        OBDModuleInformation obdModule = new OBDModuleInformation(0);
+        obdModule.set(DM5DiagnosticReadinessPacket.create(0, 0, 0, 0x22, enabledSystems, completeSystems), 1);
+        dataRepository.putObdModule(obdModule);
+
+        when(diagnosticMessageModule.requestDM26(any())).thenReturn(RequestResult.of(dm26));
+        when(diagnosticMessageModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26));
+
+        runTest();
+
+        verify(diagnosticMessageModule).setJ1939(j1939);
+        verify(diagnosticMessageModule).requestDM26(any());
+        verify(diagnosticMessageModule).requestDM26(any(), eq(0));
+
+        String expectedResults = NL + "Vehicle Composite of DM26:" + NL;
+        expectedResults += "    A/C system refrigerant         enabled, not complete" + NL;
+        expectedResults += "    Boost pressure control sys     enabled, not complete" + NL;
+        expectedResults += "    Catalyst                       enabled, not complete" + NL;
+        expectedResults += "    Cold start aid system      not enabled,     complete" + NL;
+        expectedResults += "    Comprehensive component        enabled, not complete" + NL;
+        expectedResults += "    Diesel Particulate Filter      enabled, not complete" + NL;
+        expectedResults += "    EGR/VVT system             not enabled,     complete" + NL;
+        expectedResults += "    Evaporative system             enabled, not complete" + NL;
+        expectedResults += "    Exhaust Gas Sensor         not enabled,     complete" + NL;
+        expectedResults += "    Exhaust Gas Sensor heater      enabled, not complete" + NL;
+        expectedResults += "    Fuel System                not enabled,     complete" + NL;
+        expectedResults += "    Heated catalyst            not enabled,     complete" + NL;
+        expectedResults += "    Misfire                    not enabled,     complete" + NL;
+        expectedResults += "    NMHC converting catalyst   not enabled,     complete" + NL;
+        expectedResults += "    NOx catalyst/adsorber      not enabled,     complete" + NL;
+        expectedResults += "    Secondary air system       not enabled,     complete" + NL;
+        expectedResults += NL;
+        assertEquals(expectedResults, listener.getResults());
+
+        verify(mockListener).addOutcome(PART_NUMBER,
+                                        STEP_NUMBER,
+                                        FAIL,
+                                        "6.1.14.2.e - Engine #1 (0) response indicates time since engine start is not zero");
+    }
+
+    @Test
+    public void testWarningForDuplicateSystems() {
+        var enabledSystems = List.of(
+                                     CompositeSystem.COMPREHENSIVE_COMPONENT,
+                                     CompositeSystem.EVAPORATIVE_SYSTEM);
+        var completeSystems = List.of(
+                                      CompositeSystem.AC_SYSTEM_REFRIGERANT,
+                                      CompositeSystem.BOOST_PRESSURE_CONTROL_SYS,
+                                      CompositeSystem.CATALYST,
+                                      CompositeSystem.COLD_START_AID_SYSTEM,
+                                      CompositeSystem.DIESEL_PARTICULATE_FILTER,
+                                      CompositeSystem.EGR_VVT_SYSTEM,
+                                      CompositeSystem.EXHAUST_GAS_SENSOR,
+                                      CompositeSystem.EXHAUST_GAS_SENSOR_HEATER,
+                                      CompositeSystem.FUEL_SYSTEM,
+                                      CompositeSystem.HEATED_CATALYST,
+                                      CompositeSystem.MISFIRE,
+                                      CompositeSystem.NMHC_CONVERTING_CATALYST,
+                                      CompositeSystem.SECONDARY_AIR_SYSTEM,
+                                      CompositeSystem.NOX_CATALYST_ABSORBER);
+        var dm26_0 = DM26TripDiagnosticReadinessPacket.create(0, 0, 0, enabledSystems, completeSystems);
+        var dm26_1 = DM26TripDiagnosticReadinessPacket.create(1, 0, 0, enabledSystems, completeSystems);
+
+        OBDModuleInformation obdModule0 = new OBDModuleInformation(0);
+        obdModule0.set(DM5DiagnosticReadinessPacket.create(0, 0, 0, 0x22, enabledSystems, completeSystems), 1);
+        dataRepository.putObdModule(obdModule0);
+
+        OBDModuleInformation obdModule1 = new OBDModuleInformation(1);
+        obdModule1.set(DM5DiagnosticReadinessPacket.create(1, 0, 0, 0x22, enabledSystems, completeSystems), 1);
+        dataRepository.putObdModule(obdModule1);
+
+        when(diagnosticMessageModule.requestDM26(any())).thenReturn(RequestResult.of(dm26_0, dm26_1));
+        when(diagnosticMessageModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26_0));
+        when(diagnosticMessageModule.requestDM26(any(), eq(1))).thenReturn(RequestResult.of(dm26_1));
+
+        runTest();
+
+        verify(diagnosticMessageModule).setJ1939(j1939);
+        verify(diagnosticMessageModule).requestDM26(any());
+        verify(diagnosticMessageModule).requestDM26(any(), eq(0));
+        verify(diagnosticMessageModule).requestDM26(any(), eq(1));
+
+        String expectedResults = NL + "Vehicle Composite of DM26:" + NL;
+        expectedResults += "    A/C system refrigerant     not enabled,     complete" + NL;
+        expectedResults += "    Boost pressure control sys not enabled,     complete" + NL;
+        expectedResults += "    Catalyst                   not enabled,     complete" + NL;
+        expectedResults += "    Cold start aid system      not enabled,     complete" + NL;
+        expectedResults += "    Comprehensive component        enabled, not complete" + NL;
+        expectedResults += "    Diesel Particulate Filter  not enabled,     complete" + NL;
+        expectedResults += "    EGR/VVT system             not enabled,     complete" + NL;
+        expectedResults += "    Evaporative system             enabled, not complete" + NL;
+        expectedResults += "    Exhaust Gas Sensor         not enabled,     complete" + NL;
+        expectedResults += "    Exhaust Gas Sensor heater  not enabled,     complete" + NL;
+        expectedResults += "    Fuel System                not enabled,     complete" + NL;
+        expectedResults += "    Heated catalyst            not enabled,     complete" + NL;
+        expectedResults += "    Misfire                    not enabled,     complete" + NL;
+        expectedResults += "    NMHC converting catalyst   not enabled,     complete" + NL;
+        expectedResults += "    NOx catalyst/adsorber      not enabled,     complete" + NL;
+        expectedResults += "    Secondary air system       not enabled,     complete" + NL;
+        expectedResults += NL;
+        assertEquals(expectedResults, listener.getResults());
+
+        verify(mockListener).addOutcome(PART_NUMBER,
+                                        STEP_NUMBER,
+                                        WARN,
+                                        "6.1.14.3.a - Required monitor Evaporative system is supported by more than one OBD ECU");
+    }
+
+    @Test
+    public void testFailureForDifference() {
+        var enabledSystems = List.of(
+                                     CompositeSystem.AC_SYSTEM_REFRIGERANT,
+                                     CompositeSystem.BOOST_PRESSURE_CONTROL_SYS,
+                                     CompositeSystem.CATALYST,
+                                     CompositeSystem.COMPREHENSIVE_COMPONENT,
+                                     CompositeSystem.DIESEL_PARTICULATE_FILTER,
+                                     CompositeSystem.EVAPORATIVE_SYSTEM,
+                                     CompositeSystem.EXHAUST_GAS_SENSOR_HEATER);
+        var completeSystems = List.of(
+                                      CompositeSystem.COLD_START_AID_SYSTEM,
+                                      CompositeSystem.EGR_VVT_SYSTEM,
+                                      CompositeSystem.FUEL_SYSTEM,
+                                      CompositeSystem.MISFIRE,
+                                      CompositeSystem.NMHC_CONVERTING_CATALYST,
+                                      CompositeSystem.SECONDARY_AIR_SYSTEM,
+                                      CompositeSystem.NOX_CATALYST_ABSORBER,
+                                      CompositeSystem.EXHAUST_GAS_SENSOR,
+                                      CompositeSystem.HEATED_CATALYST);
+        var dm26 = DM26TripDiagnosticReadinessPacket.create(0, 0, 0, enabledSystems, completeSystems);
+
+        OBDModuleInformation obdModule = new OBDModuleInformation(0);
+        obdModule.set(DM5DiagnosticReadinessPacket.create(0, 0, 0, 0x22, enabledSystems, completeSystems), 1);
+        dataRepository.putObdModule(obdModule);
+
+        when(diagnosticMessageModule.requestDM26(any())).thenReturn(RequestResult.of(dm26));
+
+        var dm26Ds = DM26TripDiagnosticReadinessPacket.create(0, 1, 0, enabledSystems, completeSystems);
+        when(diagnosticMessageModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26Ds));
+
+        runTest();
+
+        verify(diagnosticMessageModule).setJ1939(j1939);
+        verify(diagnosticMessageModule).requestDM26(any());
+        verify(diagnosticMessageModule).requestDM26(any(), eq(0));
+
+        String expectedResults = NL + "Vehicle Composite of DM26:" + NL;
+        expectedResults += "    A/C system refrigerant         enabled, not complete" + NL;
+        expectedResults += "    Boost pressure control sys     enabled, not complete" + NL;
+        expectedResults += "    Catalyst                       enabled, not complete" + NL;
+        expectedResults += "    Cold start aid system      not enabled,     complete" + NL;
+        expectedResults += "    Comprehensive component        enabled, not complete" + NL;
+        expectedResults += "    Diesel Particulate Filter      enabled, not complete" + NL;
+        expectedResults += "    EGR/VVT system             not enabled,     complete" + NL;
+        expectedResults += "    Evaporative system             enabled, not complete" + NL;
+        expectedResults += "    Exhaust Gas Sensor         not enabled,     complete" + NL;
+        expectedResults += "    Exhaust Gas Sensor heater      enabled, not complete" + NL;
+        expectedResults += "    Fuel System                not enabled,     complete" + NL;
+        expectedResults += "    Heated catalyst            not enabled,     complete" + NL;
+        expectedResults += "    Misfire                    not enabled,     complete" + NL;
+        expectedResults += "    NMHC converting catalyst   not enabled,     complete" + NL;
+        expectedResults += "    NOx catalyst/adsorber      not enabled,     complete" + NL;
+        expectedResults += "    Secondary air system       not enabled,     complete" + NL;
+        expectedResults += NL;
+        assertEquals(expectedResults, listener.getResults());
+
+        verify(mockListener).addOutcome(PART_NUMBER,
+                                        STEP_NUMBER,
+                                        FAIL,
+                                        "6.1.14.5.a - Difference compared to data received during global request from Engine #1 (0)");
+    }
+
+    @Test
+    public void testFailureForNoNack() {
+        var enabledSystems = List.of(
+                                     CompositeSystem.AC_SYSTEM_REFRIGERANT,
+                                     CompositeSystem.BOOST_PRESSURE_CONTROL_SYS,
+                                     CompositeSystem.CATALYST,
+                                     CompositeSystem.COMPREHENSIVE_COMPONENT,
+                                     CompositeSystem.DIESEL_PARTICULATE_FILTER,
+                                     CompositeSystem.EVAPORATIVE_SYSTEM,
+                                     CompositeSystem.EXHAUST_GAS_SENSOR_HEATER);
+        var completeSystems = List.of(
+                                      CompositeSystem.COLD_START_AID_SYSTEM,
+                                      CompositeSystem.EGR_VVT_SYSTEM,
+                                      CompositeSystem.FUEL_SYSTEM,
+                                      CompositeSystem.MISFIRE,
+                                      CompositeSystem.NMHC_CONVERTING_CATALYST,
+                                      CompositeSystem.SECONDARY_AIR_SYSTEM,
+                                      CompositeSystem.NOX_CATALYST_ABSORBER,
+                                      CompositeSystem.EXHAUST_GAS_SENSOR,
+                                      CompositeSystem.HEATED_CATALYST);
+        var dm26 = DM26TripDiagnosticReadinessPacket.create(0, 0, 0, enabledSystems, completeSystems);
+
+        OBDModuleInformation obdModule = new OBDModuleInformation(0);
+        obdModule.set(DM5DiagnosticReadinessPacket.create(0, 0, 0, 0x22, enabledSystems, completeSystems), 1);
+        dataRepository.putObdModule(obdModule);
+        when(diagnosticMessageModule.requestDM26(any(), eq(0))).thenReturn(RequestResult.of(dm26));
+
+        dataRepository.putObdModule(new OBDModuleInformation(1));
+        when(diagnosticMessageModule.requestDM26(any(), eq(1))).thenReturn(RequestResult.empty());
+
+        when(diagnosticMessageModule.requestDM26(any())).thenReturn(RequestResult.of(dm26));
+
+        runTest();
+
+        verify(diagnosticMessageModule).setJ1939(j1939);
+        verify(diagnosticMessageModule).requestDM26(any());
+        verify(diagnosticMessageModule).requestDM26(any(), eq(0));
+        verify(diagnosticMessageModule).requestDM26(any(), eq(1));
+
+        String expectedResults = NL + "Vehicle Composite of DM26:" + NL;
+        expectedResults += "    A/C system refrigerant         enabled, not complete" + NL;
+        expectedResults += "    Boost pressure control sys     enabled, not complete" + NL;
+        expectedResults += "    Catalyst                       enabled, not complete" + NL;
+        expectedResults += "    Cold start aid system      not enabled,     complete" + NL;
+        expectedResults += "    Comprehensive component        enabled, not complete" + NL;
+        expectedResults += "    Diesel Particulate Filter      enabled, not complete" + NL;
+        expectedResults += "    EGR/VVT system             not enabled,     complete" + NL;
+        expectedResults += "    Evaporative system             enabled, not complete" + NL;
+        expectedResults += "    Exhaust Gas Sensor         not enabled,     complete" + NL;
+        expectedResults += "    Exhaust Gas Sensor heater      enabled, not complete" + NL;
+        expectedResults += "    Fuel System                not enabled,     complete" + NL;
+        expectedResults += "    Heated catalyst            not enabled,     complete" + NL;
+        expectedResults += "    Misfire                    not enabled,     complete" + NL;
+        expectedResults += "    NMHC converting catalyst   not enabled,     complete" + NL;
+        expectedResults += "    NOx catalyst/adsorber      not enabled,     complete" + NL;
+        expectedResults += "    Secondary air system       not enabled,     complete" + NL;
+        expectedResults += NL;
+        assertEquals(expectedResults, listener.getResults());
+
+        verify(mockListener).addOutcome(PART_NUMBER,
+                                        STEP_NUMBER,
+                                        FAIL,
+                                        "6.1.14.5.b - OBD ECU Engine #2 (1) did not provide a response to Global query and did not provide a NACK for the DS query");
     }
 }

--- a/src/org/etools/j1939_84/controllers/part01/Part01Step14Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step14Controller.java
@@ -119,7 +119,7 @@ public class Part01Step14Controller extends StepController {
                          MonitoredSystem dm5System = getDM5System(dm26System.getId(), dm26System.getSourceAddress());
                          return dm5System != null
                                  && !dm5System.getStatus().isEnabled()
-                                 && (!dm26System.getStatus().isComplete() || dm26System.getStatus().isEnabled());
+                                 && !(dm26System.getStatus().isComplete() && !dm26System.getStatus().isEnabled());
                      })
                      .forEach(dm26System -> {
                          String moduleName = Lookup.getAddressName(dm26System.getSourceAddress());

--- a/src/org/etools/j1939_84/controllers/part01/Part01Step14Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step14Controller.java
@@ -25,7 +25,6 @@ import org.etools.j1939_84.modules.VehicleInformationModule;
 /**
  * 6.1.14 DM26: Diagnostic readiness 3
  */
-
 public class Part01Step14Controller extends StepController {
 
     private static final int PART_NUMBER = 1;
@@ -71,9 +70,9 @@ public class Part01Step14Controller extends StepController {
                                                         .filter(p -> isObdModule(p.getSourceAddress()))
                                                         .collect(Collectors.toList());
 
-        // 6.1.14.2.e. Fail if no OBD ECU provides DM26.
+        // 6.1.14.2.f. Fail if no OBD ECU provides DM26.
         if (globalPackets.isEmpty()) {
-            addFailure("6.1.14.2.e - No OBD ECU provided DM26");
+            addFailure("6.1.14.2.f - No OBD ECU provided DM26");
         } else {
             // 6.1.14.1.a.i. Create list by ECU address of all data and current status for use later in the test.
             globalPackets.forEach(this::save);
@@ -88,59 +87,80 @@ public class Part01Step14Controller extends StepController {
             getListener().onResult("");
         }
 
+        // 6.1.14.2.a. Fail if any response for any monitor supported in DM5 by a given ECU is reported as
+        // “0=monitor complete this cycle or not supported” in SP 3303 bits 1-4 and SP 3305
+        // [except comprehensive components monitor (CCM)].
         globalPackets.stream()
                      .flatMap(p -> p.getMonitoredSystems().stream())
                      .sorted()
+                     .filter(dm26System -> dm26System.getId() != CompositeSystem.COMPREHENSIVE_COMPONENT)
+                     .filter(dm26System -> {
+                         MonitoredSystem dm5System = getDM5System(dm26System.getId(), dm26System.getSourceAddress());
+                         return dm5System != null
+                                 && dm5System.getStatus().isEnabled()
+                                 && dm26System.getStatus().isComplete();
+
+                     })
                      .forEach(dm26System -> {
-                         int address = dm26System.getSourceAddress();
-                         String moduleName = Lookup.getAddressName(address);
+                         String moduleName = Lookup.getAddressName(dm26System.getSourceAddress());
                          String systemName = dm26System.getName().trim();
-                         boolean dm26SystemEnabled = dm26System.getStatus().isEnabled();
-
-                         MonitoredSystem dm5System = getDM5System(dm26System.getId(), address);
-
-                         if (dm5System != null) {
-                             boolean dm5SystemEnabled = dm5System.getStatus().isEnabled();
-                             if (!dm26SystemEnabled && dm5SystemEnabled) {
-                                 if (dm26System.getId() != CompositeSystem.COMPREHENSIVE_COMPONENT) {
-                                     // 6.1.14.2.a. Fail if any response for any monitor supported in
-                                     // DM5 by a given ECU is reported as '0=monitor complete
-                                     // this cycle or not supported' in SPN 3303 bits 1-4 and
-                                     // SPN 3305 [except comprehensive components monitor
-                                     // (CCM)].
-                                     addFailure("6.1.14.2.a - " + moduleName + " response for a monitor "
-                                             + systemName
-                                             + " in DM5 is reported as supported and is reported as not enabled by DM26 response");
-                                 }
-                             } else if (dm26SystemEnabled && !dm5SystemEnabled) {
-                                 // 6.1.14.2.b. Fail if any response for each monitor not
-                                 // supported in DM5 by a given ECU is not also
-                                 // reported in DM26 as '0=monitor complete this
-                                 // cycle or not supported' in SPN 3303 bits 5-7 and
-                                 // '0=monitor disabled for rest of this cycle or not
-                                 // supported' in SPN 3303 bits 1-2 and SPN 3304.
-                                 addFailure("6.1.14.2.b - " + moduleName + " response for a monitor "
-                                                    + systemName
-                                                    + " in DM5 is reported as not supported and is reported as enabled by DM26 response");
-                             }
-                         }
+                         addFailure("6.1.14.2.a - " + moduleName + " response for a monitor " + systemName
+                                 + " in DM5 is reported as supported and is reported as complete/not supported DM26 response");
                      });
 
-        // 6.1.14.2.c. Fail if any response indicates number of warm-ups since code clear (SPN 3302) is not zero.
+        // 6.1.14.2.b. Fail if any response for each monitor not supported in DM5 by a given ECU is not also reported
+        // in DM26 as “0=monitor complete this cycle or not supported” in SP 3303 bits 5-7 and
+        // [also reported in DM26 as] “0=monitor disabled for rest of this cycle or not supported” in
+        // SP 3303 bits 1 and 2 and SP 3304.
+        globalPackets.stream()
+                     .flatMap(p -> p.getMonitoredSystems().stream())
+                     .sorted()
+                     .filter(dm26System -> {
+                         MonitoredSystem dm5System = getDM5System(dm26System.getId(), dm26System.getSourceAddress());
+                         return dm5System != null
+                                 && !dm5System.getStatus().isEnabled()
+                                 && (!dm26System.getStatus().isComplete() || dm26System.getStatus().isEnabled());
+                     })
+                     .forEach(dm26System -> {
+                         String moduleName = Lookup.getAddressName(dm26System.getSourceAddress());
+                         String systemName = dm26System.getName().trim();
+                         addFailure("6.1.14.2.b - " + moduleName + " response for a monitor " + systemName
+                                 + " in DM5 is reported as not supported and is not reported as disabled and complete/not supported by DM26 response");
+                     });
+
+        // 6.1.14.2.c Fail if any response from an ECU indicating support for CCM monitor in DM5 reports
+        // “0=monitor disabled for rest of this cycle or not supported” in SP 3303 bit 3.
+        globalPackets.stream()
+                     .flatMap(p -> p.getMonitoredSystems().stream())
+                     .filter(sys -> sys.getId() == CompositeSystem.COMPREHENSIVE_COMPONENT)
+                     .filter(dm26System -> {
+                         MonitoredSystem dm5System = getDM5System(dm26System.getId(), dm26System.getSourceAddress());
+                         return dm5System != null
+                                 && dm5System.getStatus().isEnabled()
+                                 && !dm26System.getStatus().isEnabled();
+                     })
+                     .forEach(dm26System -> {
+                         String moduleName = Lookup.getAddressName(dm26System.getSourceAddress());
+                         String systemName = dm26System.getName().trim();
+                         addFailure("6.1.14.2.c - " + moduleName + " response for a monitor " + systemName
+                                 + " in DM5 is reported as supported and is reported as disabled/not supported by DM26 response");
+                     });
+
+        // 6.1.14.2.d. Fail if any response indicates number of warm-ups since code clear (SPN 3302) is not zero.
         globalPackets.stream()
                      .filter(packet -> packet.getWarmUpsSinceClear() != 0)
                      .map(ParsedPacket::getModuleName)
                      .forEach(moduleName -> {
-                         addFailure("6.1.14.2.c - " + moduleName
+                         addFailure("6.1.14.2.d - " + moduleName
                                  + " response indicates number of warm-ups since code clear is not zero");
                      });
 
-        // 6.1.14.2.d. Fail if any response indicates time since engine start (SPN 3301) is not zero.
+        // 6.1.14.2.e. Fail if any response indicates time since engine start (SPN 3301) is not zero.
         globalPackets.stream()
                      .filter(packet -> packet.getTimeSinceEngineStart() != 0)
                      .map(ParsedPacket::getModuleName)
                      .forEach(moduleName -> {
-                         addFailure("6.1.14.2.d - " + moduleName
+                         addFailure("6.1.14.2.e - " + moduleName
                                  + " response indicates time since engine start is not zero");
                      });
 


### PR DESCRIPTION
Resolves #977 

Re-implement failures a & b.  

6.1.14.2 Fail Criteria 

>a. Fail if any response for any monitor supported in DM5 by a given ECU is reported as “0=monitor complete this cycle or not supported” in SP 3303 bits 1-4 and SP 3305 [except comprehensive components monitor (CCM)].  

>b. Fail if any response for each monitor not supported in DM5 by a given ECU is not also reported in DM26 as “0=monitor complete this cycle or not supported” in SP 3303 bits 5-7 and [also reported in DM26 as] “0=monitor disabled for rest of this cycle or not supported” in SP 3303 bits 1 and 2 and SP 3304. [23]

Added failure c (and re-numbered subsequent failures).
>c. Fail if any response from an ECU indicating support for CCM monitor in DM5 reports “0=monitor disabled for rest of this cycle or not supported” in SP 3303 bit 3.  


