### PR TITLE
Fix #993 - Failure and warning counts incorrect in 3.0.8

### DIFF
--- a/src-test/org/etools/j1939_84/modules/SummaryModuleTest.java
+++ b/src-test/org/etools/j1939_84/modules/SummaryModuleTest.java
@@ -15,12 +15,15 @@ import org.junit.Test;
 
 public class SummaryModuleTest {
 
+    private PartResultRepository partResultRepository;
+
     private SummaryModule instance;
 
     @Before
     public void setUp() {
         PartResultRepository.setInstance(null);
-        instance = new SummaryModule();
+        partResultRepository = PartResultRepository.getInstance();
+        instance = new SummaryModule(partResultRepository);
     }
 
     @After
@@ -30,14 +33,12 @@ public class SummaryModuleTest {
 
     @Test
     public void testOutput() {
-        instance.addOutcome(1, 1, Outcome.FAIL, "Part 1 Step 1 Fail");
-        instance.addOutcome(1, 2, Outcome.INCOMPLETE, "Part 1 Step 2 Incomplete");
-        instance.addOutcome(1, 3, Outcome.WARN, "Part 1 Step 1 Warning");
-        // TIMING removed
-        // instance.addOutcome(1, 4, Outcome.TIMING, "Part 1 Step 1 Timing");
-        instance.addOutcome(1, 5, Outcome.PASS, "Part 1 Step 1 Pass");
-        instance.addOutcome(1, 6, Outcome.INFO, "Part 1 Step 1 Info");
-        instance.addOutcome(1, 7, Outcome.ABORT, "Part 1 Step 1 Fail");
+        partResultRepository.addOutcome(1, 1, Outcome.FAIL, "Part 1 Step 1 Fail");
+        partResultRepository.addOutcome(1, 2, Outcome.INCOMPLETE, "Part 1 Step 2 Incomplete");
+        partResultRepository.addOutcome(1, 3, Outcome.WARN, "Part 1 Step 1 Warning");
+        partResultRepository.addOutcome(1, 5, Outcome.PASS, "Part 1 Step 1 Pass");
+        partResultRepository.addOutcome(1, 6, Outcome.INFO, "Part 1 Step 1 Info");
+        partResultRepository.addOutcome(1, 7, Outcome.ABORT, "Part 1 Step 1 Fail");
 
         String actual = instance.generateSummary();
         String expected = "";

--- a/src/org/etools/j1939_84/controllers/Controller.java
+++ b/src/org/etools/j1939_84/controllers/Controller.java
@@ -367,7 +367,9 @@ public abstract class Controller {
 
     private void setupRun(ResultsListener listener, J1939 j1939, ReportFileModule reportFileModule) {
         setJ1939(j1939);
-        if (reportFileModule != null) {
+        if (listener instanceof CompositeResultsListener) {
+            compositeListener = (CompositeResultsListener) listener;
+        } else if (reportFileModule != null) {
             compositeListener = new CompositeResultsListener(listener, reportFileModule, partResultRepository);
         } else {
             compositeListener = new CompositeResultsListener(listener, partResultRepository);

--- a/src/org/etools/j1939_84/controllers/Controller.java
+++ b/src/org/etools/j1939_84/controllers/Controller.java
@@ -369,10 +369,8 @@ public abstract class Controller {
         setJ1939(j1939);
         if (listener instanceof CompositeResultsListener) {
             compositeListener = (CompositeResultsListener) listener;
-        } else if (reportFileModule != null) {
-            compositeListener = new CompositeResultsListener(listener, reportFileModule, partResultRepository);
         } else {
-            compositeListener = new CompositeResultsListener(listener, partResultRepository);
+            compositeListener = new CompositeResultsListener(listener, reportFileModule, partResultRepository);
         }
         ending = null;
     }

--- a/src/org/etools/j1939_84/modules/SummaryModule.java
+++ b/src/org/etools/j1939_84/modules/SummaryModule.java
@@ -9,7 +9,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.etools.j1939_84.controllers.PartResultRepository;
-import org.etools.j1939_84.model.ActionOutcome;
 import org.etools.j1939_84.model.IResult;
 import org.etools.j1939_84.model.Outcome;
 import org.etools.j1939_84.model.PartResult;
@@ -24,18 +23,17 @@ public class SummaryModule {
     private final PartResultRepository partResultRepository;
 
     public SummaryModule() {
-        partResultRepository = PartResultRepository.getInstance();
+        this(PartResultRepository.getInstance());
+    }
+
+    public SummaryModule(PartResultRepository partResultRepository) {
+        this.partResultRepository = partResultRepository;
     }
 
     private static String dots(int length) {
         char[] charArray = new char[length];
         Arrays.fill(charArray, '.');
         return new String(charArray);
-    }
-
-    public void addOutcome(int partNumber, int stepNumber, Outcome outcome, String message) {
-        StepResult stepResult = getStepResult(partNumber, stepNumber);
-        stepResult.addResult(new ActionOutcome(outcome, message));
     }
 
     public String generateSummary() {
@@ -53,10 +51,6 @@ public class SummaryModule {
 
     private List<PartResult> getPartResults() {
         return partResultRepository.getPartResults();
-    }
-
-    private StepResult getStepResult(int partNumber, int stepNumber) {
-        return partResultRepository.getStepResult(partNumber, stepNumber);
     }
 
     public long getOutcomeCount(Outcome outcome) {


### PR DESCRIPTION
Resolves #993 

Turns out the `PartResultsRespository` was being added as a listener in the `Controller` three times.  The first time was when the `OverallController` was called.  Then the listener from the `OverallController` was handed to the `PartController`, which created a new `CompositeListener` that included the `CompositeListener` from the `OverallController`.   That listener from the `PartController` was passed to the `StepController` which then created a new `CompositeListener` which added the `CompositeListener` from the `PartController` and again added the `PartResultsRespository` to the new `CompositeListener`

So the fix is to not add a `CompositeListener` to another `CompositeListener`.  Instead, if a `CompositeListener` is supplied when `setupRun()` is called, that supplied listener will be used instead of creating a new one.

I also cleaned up the `SummaryModule` (which had code is didn't really need)