### PR TITLE
Fix #1011 - SI Exhaust Sensor Test coverage messages are incorrect

### DIFF
--- a/src-test/org/etools/j1939_84/controllers/part01/TableA7RowValidatorTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/TableA7RowValidatorTest.java
@@ -1,11 +1,9 @@
-/**
+/*
  *
  */
 package org.etools.j1939_84.controllers.part01;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -19,24 +17,20 @@ import org.junit.Test;
  * @author Matt Gumbel (matt@soliddesign.net)
  *
  */
+@SuppressWarnings({ "SimplifiableAssertion" })
 public class TableA7RowValidatorTest {
 
     private TableA7RowValidator instance;
 
+    @SuppressWarnings("SameParameterValue")
     private static ExpectedTestResult expectedTestResult(int spn, int fmi) {
         return new ExpectedTestResult(spn, fmi);
     }
 
     private static ScaledTestResult scaledTestResult(int spn, int fmi) {
-        ScaledTestResult mock = mock(ScaledTestResult.class);
-        when(mock.getSpn()).thenReturn(spn);
-        when(mock.getFmi()).thenReturn(fmi);
-        return mock;
+        return ScaledTestResult.create(247, spn, fmi, 0, 0, 0, 0);
     }
 
-    /**
-     * @throws java.lang.Exception
-     */
     @Before
     public void setUp() throws Exception {
         instance = new TableA7RowValidator();
@@ -151,6 +145,20 @@ public class TableA7RowValidatorTest {
         expectedTestResults.add(expectedTestResult(3055, 18));
 
         assertEquals(true, instance.isValid(actualTestResults, expectedTestResults, 2));
+    }
+
+    @Test
+    public void testInvalidMin2WithDuplicates() {
+        Collection<ScaledTestResult> actualTestResults = new ArrayList<>();
+        actualTestResults.add(scaledTestResult(157, 18));
+        actualTestResults.add(scaledTestResult(157, 18));
+
+        Collection<ExpectedTestResult> expectedTestResults = new ArrayList<>();
+        expectedTestResults.add(expectedTestResult(157, 18));
+        expectedTestResults.add(expectedTestResult(157, 17));
+        expectedTestResults.add(expectedTestResult(157, 16));
+
+        assertEquals(false, instance.isValid(actualTestResults, expectedTestResults, 2));
     }
 
     @Test

--- a/src-test/org/etools/j1939_84/controllers/part01/TableA7ValidatorTest.java
+++ b/src-test/org/etools/j1939_84/controllers/part01/TableA7ValidatorTest.java
@@ -103,6 +103,7 @@ public class TableA7ValidatorTest {
         return testResults;
     }
 
+    @SuppressWarnings("SameParameterValue")
     private static void remove(Collection<ScaledTestResult> testResults, int spn, int fmi) {
         for (ScaledTestResult testResult : testResults) {
             if (testResult.getSpn() == spn && testResult.getFmi() == fmi) {
@@ -140,7 +141,7 @@ public class TableA7ValidatorTest {
         verify(listener).addOutcome(PART_NUMBER,
                                     STEP_NUMBER,
                                     FAIL,
-                                    "6.1.12.2.a (A7.2.a) - Fuel system pressure control low is missing required Test Result, one of: 157:18, 164:18, 3055:18");
+                                    "6.1.12.2.a (A7.2.a) - Fuel system pressure control low is missing required Test Result, 3 of: 157:18, 164:18, 3055:18");
     }
 
     @Test

--- a/src/org/etools/j1939_84/controllers/part01/TableA7RowValidator.java
+++ b/src/org/etools/j1939_84/controllers/part01/TableA7RowValidator.java
@@ -4,6 +4,7 @@
 package org.etools.j1939_84.controllers.part01;
 
 import java.util.Collection;
+import java.util.HashSet;
 
 import org.etools.j1939_84.bus.j1939.packets.ScaledTestResult;
 import org.etools.j1939_84.model.ExpectedTestResult;
@@ -19,8 +20,8 @@ public class TableA7RowValidator {
                            int minimumContains) {
 
         int matches = 0;
-        for (ExpectedTestResult expectedTestResult : expectedTestResults) {
-            for (ScaledTestResult scaledTestResult : scaledTestResults) {
+        for (ScaledTestResult scaledTestResult : new HashSet<>(scaledTestResults)) {
+            for (ExpectedTestResult expectedTestResult : expectedTestResults) {
                 if (expectedTestResult.matches(scaledTestResult)) {
                     if (++matches >= minimumContains) {
                         return true;

--- a/src/org/etools/j1939_84/controllers/part01/TableA7Validator.java
+++ b/src/org/etools/j1939_84/controllers/part01/TableA7Validator.java
@@ -174,12 +174,8 @@ public class TableA7Validator {
                 var list = expectedTestResults.stream()
                                               .map(r -> r.getSpn() + ":" + r.getFmi())
                                               .collect(Collectors.joining(", "));
-                String message = "6.1.12.2.a (A7.2.a) - " + monitorName + " is missing required Test Result";
-                if (expectedTestResults.size() > 1) {
-                    message = message + ", one of: " + list;
-                } else {
-                    message = message + ": " + list;
-                }
+                String message = "6.1.12.2.a (A7.2.a) - " + monitorName + " is missing required Test Result, "
+                        + expectedTestResults.size() + " of: " + list;
                 listener.addOutcome(PART_NUMBER, STEP_NUMBER, FAIL, message);
             }
             return isValid;


### PR DESCRIPTION
Resolves #1011
This bug contains two problems.

The first is the message was wrong.  It incorrectly indicated the number of results required. I changed the message to just include the required number. (Simple logic error, now fixed.)

The second didn't consider duplicates. Thus if we are expected _two_ scaled tests results and got two of the same, the ECU passed.  That's fixed now.