### PR TITLE
Fix #1015 CAL-ID and CVN incorrectly listed as NA in Failure messages

### DIFF
--- a/src-test/org/etools/j1939_84/bus/j1939/J1939DaRepositoryTest.java
+++ b/src-test/org/etools/j1939_84/bus/j1939/J1939DaRepositoryTest.java
@@ -4,9 +4,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -22,7 +20,7 @@ import org.junit.Test;
 
 public class J1939DaRepositoryTest {
 
-    private static String[] variableLengthDMs = new String[] { "DM19", "DM24", "DM25", "DM30", "DM31", "DM33" };
+    private static final String[] variableLengthDMs = new String[] { "DM19", "DM24", "DM25", "DM30", "DM31", "DM33" };
 
     @Test
     public void test3069() {
@@ -33,12 +31,13 @@ public class J1939DaRepositoryTest {
         assertNotEquals("Slot", "UNK", j1939.findSLOT(j1939.findSpnDefinition(SPN).getSlotNumber(), SPN).getType());
     }
 
+    @SuppressWarnings("OptionalGetWithoutIsPresent")
     @Test
     public void testGeneralPacketContaining3069() {
-        Packet packet = Packet.create(0xC1FF, 0x00, 0, 0, 0, 0, 0, 0, 0, 0);
+        Packet packet = Packet.create(0xC1FF, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88);
         var genericPacket = new GenericPacket(packet);
         System.out.println(genericPacket);
-        assertEquals(0.0, genericPacket.getSpn(3069).get().getValue(), 0.0);
+        assertEquals(8721.0, genericPacket.getSpn(3069).get().getValue(), 0.0);
     }
 
     @Test

--- a/src-test/org/etools/j1939_84/controllers/TableA1ValidatorTest.java
+++ b/src-test/org/etools/j1939_84/controllers/TableA1ValidatorTest.java
@@ -20,6 +20,8 @@ import java.util.List;
 
 import org.etools.j1939_84.bus.Packet;
 import org.etools.j1939_84.bus.j1939.J1939DaRepository;
+import org.etools.j1939_84.bus.j1939.packets.DM19CalibrationInformationPacket;
+import org.etools.j1939_84.bus.j1939.packets.DM24SPNSupportPacket;
 import org.etools.j1939_84.bus.j1939.packets.GenericPacket;
 import org.etools.j1939_84.bus.j1939.packets.SupportedSPN;
 import org.etools.j1939_84.bus.j1939.packets.model.PgnDefinition;
@@ -302,5 +304,22 @@ public class TableA1ValidatorTest {
                                         WARN,
                                         "6.1.26 - N.6 SPN 190 provided by non-OBD ECU Turbocharger (2)");
         verify(mockListener).addOutcome(1, 26, INFO, "6.1.26 - N.6 SPN 96 provided by non-OBD ECU Turbocharger (2)");
+    }
+
+    @Test
+    public void testNotAvailableForDM19() {
+        OBDModuleInformation obdModuleInformation = new OBDModuleInformation(0);
+        obdModuleInformation.set(DM24SPNSupportPacket.create(0,
+                                                             SupportedSPN.create(1634, true, true, true, 15),
+                                                             SupportedSPN.create(1635, true, true, true, 15)),
+                                 1);
+        dataRepository.putObdModule(obdModuleInformation);
+
+        var calInfo = new DM19CalibrationInformationPacket.CalibrationInformation("CALID", "BADBEEF");
+        var packet = DM19CalibrationInformationPacket.create(0, 0xF9, calInfo);
+
+        instance.reportNotAvailableSPNs(packet, listener, "6.1.26");
+
+        assertEquals(List.of(), listener.getOutcomes());
     }
 }

--- a/src/org/etools/j1939_84/bus/j1939/packets/GenericPacket.java
+++ b/src/org/etools/j1939_84/bus/j1939/packets/GenericPacket.java
@@ -93,8 +93,10 @@ public class GenericPacket extends ParsedPacket {
             byte[] bytes = getPacket().getBytes();
             for (SpnDefinition definition : spnDefinitions) {
                 Slot slot = getJ1939DaRepository().findSLOT(definition.getSlotNumber(), definition.getSpnId());
-                byte[] data = parser.parse(bytes, definition, slot.getLength());
-                spns.add(new Spn(definition.getSpnId(), definition.getLabel(), slot, data));
+                if (slot.getLength() != 0) {
+                    byte[] data = parser.parse(bytes, definition, slot.getLength());
+                    spns.add(new Spn(definition.getSpnId(), definition.getLabel(), slot, data));
+                }
             }
         }
         return spns;

--- a/src/org/etools/j1939_84/bus/simulated/Engine.java
+++ b/src/org/etools/j1939_84/bus/simulated/Engine.java
@@ -428,6 +428,8 @@ public class Engine implements AutoCloseable {
                                                       SupportedSPN.create(1325, true, false, false, 1),
                                                       SupportedSPN.create(1326, true, false, false, 1),
                                                       SupportedSPN.create(1413, false, true, false, 1),
+                                                      SupportedSPN.create(1634, false, true, false, 15),
+                                                      SupportedSPN.create(1635, false, true, false, 4),
                                                       SupportedSPN.create(2630, true, false, false, 1),
                                                       SupportedSPN.create(2791, false, true, false, 1),
                                                       SupportedSPN.create(2978, false, true, false, 1),

--- a/src/org/etools/j1939_84/controllers/TableA1Validator.java
+++ b/src/org/etools/j1939_84/controllers/TableA1Validator.java
@@ -421,7 +421,7 @@ public class TableA1Validator {
             if (forceReporting || !supportedSPNs.isEmpty()) {
                 listener.onResult("PGN " + pgn + " with Supported SPNs " + String.join(", ", supportedSPNs));
                 listener.onResult(packet.getPacket().toTimeString());
-                listener.onResult("Found: " + packet.toString());
+                listener.onResult("Found: " + packet);
             }
 
             Set<Integer> modulePackets = getReportedPGNs(moduleAddress);

--- a/src/org/etools/j1939_84/ui/UserInterfaceView.java
+++ b/src/org/etools/j1939_84/ui/UserInterfaceView.java
@@ -22,7 +22,6 @@ import java.util.concurrent.Executor;
 import java.util.logging.Level;
 import java.util.prefs.Preferences;
 
-import javax.swing.AbstractButton;
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
@@ -73,7 +72,6 @@ public class UserInterfaceView implements UserInterfaceContract.View {
     private JButton abortButton;
     private JComboBox<Adapter> adapterComboBox;
     private JComboBox<String> speedComboBox;
-    private JLabel adapterLabel;
     private JLabel calsLabel;
     private JScrollPane calsScrollPane;
     private JTextArea calsTextField;
@@ -356,12 +354,12 @@ public class UserInterfaceView implements UserInterfaceContract.View {
             if (isAutoMode()) {
                 adapterComboBox.setSelectedIndex(0);
                 getController().onAdapterComboBoxItemSelected(adapterComboBox.getItemAt(0),
-                                                              speedComboBox.getItemAt(speedComboBox.getSelectedIndex()));
+                                                              getSpeedComboBox().getItemAt(getSpeedComboBox().getSelectedIndex()));
             }
             adapterComboBox.addItemListener(e -> {
                 if (e.getStateChange() == ItemEvent.SELECTED) {
-                    speedComboBox.removeAllItems();
-                    ((Adapter) e.getItem()).getConnectionStrings().forEach(s -> speedComboBox.addItem(s));
+                    getSpeedComboBox().removeAllItems();
+                    ((Adapter) e.getItem()).getConnectionStrings().forEach(s -> getSpeedComboBox().addItem(s));
                     getSpeedComboBox().setSelectedItem("J1939:Baud=Auto");
                 }
             });


### PR DESCRIPTION
Resolves #1015 

Don't continue parsing SPNs when the data is bad. Also fixed problem when running the app in autoMode.  Added tests to detect this issue.