### PR TITLE
Fix #1028 - No Failure message for null ESN

### DIFF
--- a/src/org/etools/j1939_84/controllers/part01/Part01Step09Controller.java
+++ b/src/org/etools/j1939_84/controllers/part01/Part01Step09Controller.java
@@ -104,6 +104,9 @@ public class Part01Step09Controller extends StepController {
                     addFailure("6.1.9.2.c - Serial number field (SP 588) from " + function0Name
                             + " does not end in five numeric characters");
                 }
+            } else {
+                addFailure("6.1.9.2.c - Serial number field (SP 588) from " + function0Name
+                        + " does not end in five numeric characters");
             }
 
             // 6.1.9.3.a. INFO if the serial number field (SP 588) from any function 0 device is


### PR DESCRIPTION
Resolves #1028 

We will not report the SN doesn't end in 5 numeric digits of the SN is not at least 5 digits long.